### PR TITLE
Ran prettier on style.css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,1 +1,5714 @@
-﻿.card,.highlight,.highlight pre,.textarea,embed,img,object{max-width:100%}a,hr{padding:0}a,button,input[type=button],input[type=file],input[type=submit],label{cursor:pointer}a,button,input,select,textarea{margin:0}a,input[type=checkbox],input[type=radio]{vertical-align:baseline}a:hover,strong,table th{color:#222324}.container,sub,sup{position:relative}.is-block,article,aside,details,figure,footer,header,hgroup,hr,nav,pre code,section,summary{display:block}.button,.delete,.input,.modal-close,.progress,.select select,.textarea{-moz-appearance:none;-webkit-appearance:none}.heading,.menu-label{letter-spacing:1px;text-transform:uppercase}.hero,.modal-card,.tile.is-vertical{-webkit-box-orient:vertical;-webkit-box-direction:normal}abbr,address,article,aside,audio,b,blockquote,body,body div,caption,cite,code,dd,del,details,dfn,dl,dt,em,fieldset,figure,footer,form,h1,h2,h3,h4,h5,h6,header,html,i,iframe,img,ins,kbd,label,legend,li,mark,menu,nav,object,ol,p,pre,q,samp,section,small,span,strong,sub,summary,sup,table,tbody,td,tfoot,th,thead,time,tr,ul,var,video{margin:0;padding:0;border:0;font-size:100%;font-weight:400;vertical-align:baseline;background:0 0}td,td img{vertical-align:top}pre,pre code{background-color:#f5f7fa;color:#42464c}*,:after,:before{box-sizing:inherit}ul{list-style:none}blockquote,q{quotes:none}blockquote:after,blockquote:before,q:after,q:before{content:'';content:none}.is-clearfix:after,.notification:after,.select:after{content:" "}a{font-size:100%;background:0 0;color:#2077b2;text-decoration:none;-webkit-transition:none 86ms ease-out;transition:none 86ms ease-out}del{text-decoration:line-through}abbr[title],dfn[title]{border-bottom:1px dotted #000;cursor:help}th{font-weight:700;vertical-align:bottom}body,code,td{font-weight:400}hr{height:1px;border:0;border-top:1px solid #ccc;border-top-color:#d3d6db;margin:40px 0}input,select{vertical-align:middle}input,select,textarea{font:99% sans-serif}table{border-collapse:collapse;border-spacing:0;font:100%;width:100%}sub,sup{font-size:75%;line-height:0}sup{top:-.5em}sub{bottom:-.25em}code,kbd,pre,samp{font-family:monospace,sans-serif}button,input[type=button]{width:auto;overflow:visible}@-webkit-keyframes spin-around{from{-webkit-transform:rotate(0);transform:rotate(0)}to{-webkit-transform:rotate(359deg);transform:rotate(359deg)}}@keyframes spin-around{from{-webkit-transform:rotate(0);transform:rotate(0)}to{-webkit-transform:rotate(359deg);transform:rotate(359deg)}}html{box-sizing:border-box;font-size:14px;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;min-width:300px;overflow-x:hidden;overflow-y:scroll;text-rendering:optimizeLegibility}body,button,input,select,textarea{font-family:"游ゴシック",YuGothic,"ヒラギノ角ゴ Pro","Hiragino Kaku Gothic Pro","メイリオ",Meiryo,sans-serif}code,pre{-moz-osx-font-smoothing:auto;-webkit-font-smoothing:auto;font-family:"Source Code Pro",Monaco,Inconsolata,monospace;line-height:1.25}body{color:#42464c;font-size:1rem;line-height:1.428571428571429}code{padding:1px 2px 2px}.button,.input,.textarea,table td,table th{vertical-align:top}small{font-size:11px}span{font-style:inherit;font-weight:inherit}.label,strong{font-weight:700}pre{white-space:pre;word-wrap:normal}.button,.nav-left,.table td.is-icon,.table th.is-icon,.tabs,.tag{white-space:nowrap}pre code{overflow-x:auto;padding:16px 20px}.box,.button{background-color:#fff}table td,table th{text-align:left}.has-text-centered{text-align:center}.block:not(:last-child),.box:not(:last-child),.content:not(:last-child),.highlight:not(:last-child),.level:not(:last-child),.message:not(:last-child),.notification:not(:last-child),.progress:not(:last-child),.subtitle:not(:last-child),.tabs:not(:last-child),.title:not(:last-child){margin-bottom:20px}@media screen and (min-width:980px){.container{margin:0 auto;max-width:960px}.container.is-fluid{margin:0 20px;max-width:none}.is-block-desktop{display:block!important}}@media screen and (max-width:768px){.is-block-mobile{display:block!important}}@media screen and (min-width:769px){.is-block-tablet{display:block!important}}@media screen and (min-width:769px) and (max-width:979px){.is-block-tablet-only{display:block!important}}@media screen and (max-width:979px){.is-block-touch{display:block!important}}@media screen and (min-width:980px) and (max-width:1179px){.is-block-desktop-only{display:block!important}}@media screen and (min-width:1180px){.container{max-width:1200px}.is-block-widescreen{display:block!important}}.is-flex{display:-webkit-box;display:-ms-flexbox;display:flex}@media screen and (max-width:768px){.is-flex-mobile{display:-webkit-box!important;display:-ms-flexbox!important;display:flex!important}}@media screen and (min-width:769px){.is-flex-tablet{display:-webkit-box!important;display:-ms-flexbox!important;display:flex!important}}@media screen and (min-width:769px) and (max-width:979px){.is-flex-tablet-only{display:-webkit-box!important;display:-ms-flexbox!important;display:flex!important}}@media screen and (max-width:979px){.is-flex-touch{display:-webkit-box!important;display:-ms-flexbox!important;display:flex!important}}@media screen and (min-width:980px){.is-flex-desktop{display:-webkit-box!important;display:-ms-flexbox!important;display:flex!important}}@media screen and (min-width:980px) and (max-width:1179px){.is-flex-desktop-only{display:-webkit-box!important;display:-ms-flexbox!important;display:flex!important}}@media screen and (min-width:1180px){.is-flex-widescreen{display:-webkit-box!important;display:-ms-flexbox!important;display:flex!important}}.is-inline{display:inline}@media screen and (max-width:768px){.is-inline-mobile{display:inline!important}}@media screen and (min-width:769px){.is-inline-tablet{display:inline!important}}@media screen and (min-width:769px) and (max-width:979px){.is-inline-tablet-only{display:inline!important}}@media screen and (max-width:979px){.is-inline-touch{display:inline!important}}@media screen and (min-width:980px){.is-inline-desktop{display:inline!important}}@media screen and (min-width:980px) and (max-width:1179px){.is-inline-desktop-only{display:inline!important}}@media screen and (min-width:1180px){.is-inline-widescreen{display:inline!important}}.is-inline-block{display:inline-block}@media screen and (max-width:768px){.is-inline-block-mobile{display:inline-block!important}}@media screen and (min-width:769px){.is-inline-block-tablet{display:inline-block!important}}@media screen and (min-width:769px) and (max-width:979px){.is-inline-block-tablet-only{display:inline-block!important}}@media screen and (max-width:979px){.is-inline-block-touch{display:inline-block!important}}@media screen and (min-width:980px){.is-inline-block-desktop{display:inline-block!important}}@media screen and (min-width:980px) and (max-width:1179px){.is-inline-block-desktop-only{display:inline-block!important}}@media screen and (min-width:1180px){.is-inline-block-widescreen{display:inline-block!important}}.is-inline-flex{display:-webkit-inline-box;display:-ms-inline-flexbox;display:inline-flex}@media screen and (max-width:768px){.is-inline-flex-mobile{display:-webkit-inline-box!important;display:-ms-inline-flexbox!important;display:inline-flex!important}}@media screen and (min-width:769px){.is-inline-flex-tablet{display:-webkit-inline-box!important;display:-ms-inline-flexbox!important;display:inline-flex!important}}@media screen and (min-width:769px) and (max-width:979px){.is-inline-flex-tablet-only{display:-webkit-inline-box!important;display:-ms-inline-flexbox!important;display:inline-flex!important}}@media screen and (max-width:979px){.is-inline-flex-touch{display:-webkit-inline-box!important;display:-ms-inline-flexbox!important;display:inline-flex!important}}@media screen and (min-width:980px){.is-inline-flex-desktop{display:-webkit-inline-box!important;display:-ms-inline-flexbox!important;display:inline-flex!important}}@media screen and (min-width:980px) and (max-width:1179px){.is-inline-flex-desktop-only{display:-webkit-inline-box!important;display:-ms-inline-flexbox!important;display:inline-flex!important}}@media screen and (min-width:1180px){.is-inline-flex-widescreen{display:-webkit-inline-box!important;display:-ms-inline-flexbox!important;display:inline-flex!important}}.is-clearfix:after{clear:both;display:table}.is-pulled-left{float:left}.is-pulled-right{float:right}.is-clipped{overflow:hidden!important}.is-overlay{bottom:0;left:0;position:absolute;right:0;top:0}.has-text-left{text-align:left}.has-text-right{text-align:right}.is-hidden{display:none!important}@media screen and (max-width:768px){.is-hidden-mobile{display:none!important}}@media screen and (min-width:769px){.is-hidden-tablet{display:none!important}}@media screen and (min-width:769px) and (max-width:979px){.is-hidden-tablet-only{display:none!important}}@media screen and (max-width:979px){.is-hidden-touch{display:none!important}}@media screen and (min-width:980px){.is-hidden-desktop{display:none!important}}@media screen and (min-width:980px) and (max-width:1179px){.is-hidden-desktop-only{display:none!important}}@media screen and (min-width:1180px){.is-hidden-widescreen{display:none!important}}.is-disabled{pointer-events:none}.is-marginless{margin:0!important}.box{border-radius:5px;box-shadow:0 2px 3px rgba(17,17,17,.1),0 0 0 1px rgba(17,17,17,.1);display:block;padding:20px}a.box:focus,a.box:hover{box-shadow:0 2px 3px rgba(17,17,17,.1),0 0 0 1px #2077b2}a.box:active{box-shadow:inset 0 1px 2px rgba(17,17,17,.2),0 0 0 1px #2077b2}.button{-webkit-box-align:center;-ms-flex-align:center;align-items:center;border:1px solid #d3d6db;border-radius:3px;color:#222324;display:-webkit-inline-box;display:-ms-inline-flexbox;display:inline-flex;font-size:14px;height:32px;line-height:24px;position:relative;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;padding-left:10px;padding-right:10px;text-align:center}.button:hover{border-color:#aeb1b5}.button.is-active,.button:active,.button:focus{border-color:#2077b2;outline:0}.button.is-disabled,.button[disabled]{background-color:#f5f7fa;border-color:#d3d6db;cursor:not-allowed;pointer-events:none;opacity:.5}.button.is-white,.button.is-white:active{border-color:transparent}.button.is-disabled::-moz-placeholder,.button[disabled]::-moz-placeholder{color:rgba(34,35,36,.3)}.button.is-disabled::-webkit-input-placeholder,.button[disabled]::-webkit-input-placeholder{color:rgba(34,35,36,.3)}.button.is-disabled:-moz-placeholder,.button[disabled]:-moz-placeholder{color:rgba(34,35,36,.3)}.button.is-disabled:-ms-input-placeholder,.button[disabled]:-ms-input-placeholder{color:rgba(34,35,36,.3)}.button strong{color:inherit}.button small{display:block;font-size:11px;line-height:1;margin-top:5px}.button .icon:first-child,.button .tag:first-child{margin-left:-2px;margin-right:4px}.button .icon:last-child,.button .tag:last-child{margin-left:4px;margin-right:-2px}.button.is-active,.button:focus,.button:hover{color:#222324}.button:active{box-shadow:inset 0 1px 2px rgba(17,17,17,.2)}.button.is-white{background-color:#fff;color:#111}.button.is-white.is-active,.button.is-white:focus,.button.is-white:hover{background-color:#e6e6e6;border-color:transparent;color:#111}.button.is-white.is-inverted{background-color:#111;color:#fff}.button.is-white.is-inverted:hover{background-color:#040404}.button.is-white.is-loading:after{border-color:transparent transparent #111 #111!important}.button.is-white.is-outlined{background-color:transparent;border-color:#fff;color:#fff}.button.is-white.is-outlined:focus,.button.is-white.is-outlined:hover{background-color:#fff;border-color:#fff;color:#111}.button.is-black,.button.is-black:active{border-color:transparent}.button.is-black{background-color:#111;color:#fff}.button.is-black.is-active,.button.is-black:focus,.button.is-black:hover{background-color:#000;border-color:transparent;color:#fff}.button.is-black.is-inverted{background-color:#fff;color:#111}.button.is-black.is-inverted:hover{background-color:#f2f2f2}.button.is-black.is-loading:after{border-color:transparent transparent #fff #fff!important}.button.is-black.is-outlined{background-color:transparent;border-color:#111;color:#111}.button.is-black.is-outlined:focus,.button.is-black.is-outlined:hover{background-color:#111;border-color:#111;color:#fff}.button.is-light,.button.is-light:active{border-color:transparent}.button.is-light{background-color:#f5f7fa;color:#42464c}.button.is-light.is-active,.button.is-light:focus,.button.is-light:hover{background-color:#d3dce9;border-color:transparent;color:#42464c}.button.is-light.is-inverted{background-color:#42464c;color:#f5f7fa}.button.is-light.is-inverted:hover{background-color:#36393e}.button.is-light.is-loading:after{border-color:transparent transparent #42464c #42464c!important}.button.is-light.is-outlined{background-color:transparent;border-color:#f5f7fa;color:#f5f7fa}.button.is-light.is-outlined:focus,.button.is-light.is-outlined:hover{background-color:#f5f7fa;border-color:#f5f7fa;color:#42464c}.button.is-dark,.button.is-dark:active{border-color:transparent}.button.is-dark{background-color:#42464c;color:#f5f7fa}.button.is-dark.is-active,.button.is-dark:focus,.button.is-dark:hover{background-color:#2a2d31;border-color:transparent;color:#f5f7fa}.button.is-dark.is-inverted{background-color:#f5f7fa;color:#42464c}.button.is-dark.is-inverted:hover{background-color:#e4e9f2}.button.is-dark.is-loading:after{border-color:transparent transparent #f5f7fa #f5f7fa!important}.button.is-dark.is-outlined{background-color:transparent;border-color:#42464c;color:#42464c}.button.is-dark.is-outlined:focus,.button.is-dark.is-outlined:hover{background-color:#42464c;border-color:#42464c;color:#f5f7fa}.button.is-primary,.button.is-primary:active{border-color:transparent}.button.is-primary{background-color:#2077b2;color:#fff}.button.is-primary.is-active,.button.is-primary:focus,.button.is-primary:hover{background-color:#185a87;border-color:transparent;color:#fff}.button.is-primary.is-inverted{background-color:#fff;color:#2077b2}.button.is-primary.is-inverted:hover{background-color:#f2f2f2}.button.is-primary.is-loading:after{border-color:transparent transparent #fff #fff!important}.button.is-primary.is-outlined{background-color:transparent;border-color:#2077b2;color:#2077b2}.button.is-primary.is-outlined:focus,.button.is-primary.is-outlined:hover{background-color:#2077b2;border-color:#2077b2;color:#fff}.button.is-info,.button.is-info:active{border-color:transparent}.button.is-info{background-color:#2077b2;color:#fff}.button.is-info.is-active,.button.is-info:focus,.button.is-info:hover{background-color:#185a87;border-color:transparent;color:#fff}.button.is-info.is-inverted{background-color:#fff;color:#2077b2}.button.is-info.is-inverted:hover{background-color:#f2f2f2}.button.is-info.is-loading:after{border-color:transparent transparent #fff #fff!important}.button.is-info.is-outlined{background-color:transparent;border-color:#2077b2;color:#2077b2}.button.is-info.is-outlined:focus,.button.is-info.is-outlined:hover{background-color:#2077b2;border-color:#2077b2;color:#fff}.button.is-success,.button.is-success:active{border-color:transparent}.button.is-success{background-color:#97cd76;color:#fff}.button.is-success.is-active,.button.is-success:focus,.button.is-success:hover{background-color:#7bbf51;border-color:transparent;color:#fff}.button.is-success.is-inverted{background-color:#fff;color:#97cd76}.button.is-success.is-inverted:hover{background-color:#f2f2f2}.button.is-success.is-loading:after{border-color:transparent transparent #fff #fff!important}.button.is-success.is-outlined{background-color:transparent;border-color:#97cd76;color:#97cd76}.button.is-success.is-outlined:focus,.button.is-success.is-outlined:hover{background-color:#97cd76;border-color:#97cd76;color:#fff}.button.is-warning,.button.is-warning:active{border-color:transparent}.button.is-warning{background-color:#fce473;color:rgba(17,17,17,.5)}.button.is-warning.is-active,.button.is-warning:focus,.button.is-warning:hover{background-color:#fbda41;border-color:transparent;color:rgba(17,17,17,.5)}.button.is-warning.is-inverted{background-color:rgba(17,17,17,.5);color:#fce473}.button.is-warning.is-inverted:hover{background-color:rgba(4,4,4,.5)}.button.is-warning.is-loading:after{border-color:transparent transparent rgba(17,17,17,.5) rgba(17,17,17,.5)!important}.button.is-warning.is-outlined{background-color:transparent;border-color:#fce473;color:#fce473}.button.is-warning.is-outlined:focus,.button.is-warning.is-outlined:hover{background-color:#fce473;border-color:#fce473;color:rgba(17,17,17,.5)}.button.is-danger,.button.is-danger:active{border-color:transparent}.button.is-danger{background-color:#ed6c63;color:#fff}.button.is-danger.is-active,.button.is-danger:focus,.button.is-danger:hover{background-color:#e84135;border-color:transparent;color:#fff}.button.is-danger.is-inverted{background-color:#fff;color:#ed6c63}.button.is-danger.is-inverted:hover{background-color:#f2f2f2}.button.is-danger.is-loading:after{border-color:transparent transparent #fff #fff!important}.button.is-danger.is-outlined{background-color:transparent;border-color:#ed6c63;color:#ed6c63}.button.is-danger.is-outlined:focus,.button.is-danger.is-outlined:hover{background-color:#ed6c63;border-color:#ed6c63;color:#fff}.button.is-link{background-color:transparent;border-color:transparent;color:#42464c;text-decoration:underline}.button.is-link:focus,.button.is-link:hover{background-color:#d3d6db;color:#222324}.button.is-small{border-radius:2px;font-size:11px;height:24px;line-height:16px;padding-left:6px;padding-right:6px}.button.is-medium{font-size:18px;height:40px;padding-left:14px;padding-right:14px}.button.is-large{font-size:22px;height:48px;padding-left:20px;padding-right:20px}.button.is-fullwidth{display:-webkit-box;display:-ms-flexbox;display:flex;width:100%}.button.is-loading{color:transparent!important;pointer-events:none}.button.is-loading:after{left:50%;margin-left:-8px;margin-top:-8px;top:50%;position:absolute!important}.content a:not(.button){border-bottom:1px solid #d3d6db}.content a:not(.button):visited{color:#847bb9}.content a:not(.button):hover{border-bottom-color:#2077b2}.content li+li{margin-top:.25em}.content ol,.content ul{margin-left:2em;margin-right:2em;margin-top:1em}.content blockquote:not(:last-child),.content ol:not(:last-child),.content p:not(:last-child),.content ul:not(:last-child){margin-bottom:1em}.content h1,.content h2,.content h3,.content h4,.content h5,.content h6{color:#B52323;font-weight:300;margin-bottom:20px}.content blockquote{background-color:#f5f7fa;border-left:5px solid #d3d6db;padding:1.5em}.content ol{list-style:decimal}.content ul{list-style:disc}.content ul ul{list-style-type:circle;margin-top:.5em}.content ul ul ul,.related ul{list-style-type:square}.content.is-medium{font-size:18px}.content.is-medium code{font-size:14px}.content.is-large{font-size:24px}.content.is-large code{font-size:18px}.input,.textarea{-webkit-box-align:center;-ms-flex-align:center;align-items:center;background-color:#fff;border:1px solid #d3d6db;border-radius:3px;color:#222324;display:-webkit-inline-box;display:-ms-inline-flexbox;display:inline-flex;font-size:14px;height:32px;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start;line-height:24px;padding-left:8px;padding-right:8px;position:relative;box-shadow:inset 0 1px 2px rgba(17,17,17,.1);max-width:100%;width:100%}.input:hover,.textarea:hover{border-color:#aeb1b5}.input.is-active,.input:active,.input:focus,.is-active.textarea,.textarea:active,.textarea:focus{border-color:#2077b2;outline:0}.input.is-disabled,.input[disabled],.is-disabled.textarea,[disabled].textarea{background-color:#f5f7fa;border-color:#d3d6db;cursor:not-allowed;pointer-events:none}.checkbox input,.radio input,.select select{cursor:pointer}.input.is-disabled::-moz-placeholder,.input[disabled]::-moz-placeholder,.is-disabled.textarea::-moz-placeholder,[disabled].textarea::-moz-placeholder{color:rgba(34,35,36,.3)}.input.is-disabled::-webkit-input-placeholder,.input[disabled]::-webkit-input-placeholder,.is-disabled.textarea::-webkit-input-placeholder,[disabled].textarea::-webkit-input-placeholder{color:rgba(34,35,36,.3)}.input.is-disabled:-moz-placeholder,.input[disabled]:-moz-placeholder,.is-disabled.textarea:-moz-placeholder,[disabled].textarea:-moz-placeholder{color:rgba(34,35,36,.3)}.input.is-disabled:-ms-input-placeholder,.input[disabled]:-ms-input-placeholder,.is-disabled.textarea:-ms-input-placeholder,[disabled].textarea:-ms-input-placeholder{color:rgba(34,35,36,.3)}.input.is-white,.is-white.textarea{border-color:#fff}.input.is-black,.is-black.textarea{border-color:#111}.input.is-light,.is-light.textarea{border-color:#f5f7fa}.input.is-dark,.is-dark.textarea{border-color:#42464c}.input.is-info,.input.is-primary,.is-info.textarea,.is-primary.textarea{border-color:#2077b2}.input.is-success,.is-success.textarea{border-color:#97cd76}.input.is-warning,.is-warning.textarea{border-color:#fce473}.input.is-danger,.is-danger.textarea{border-color:#ed6c63}.input[type=search],[type=search].textarea{border-radius:290486px}.input.is-small,.is-small.textarea{border-radius:2px;font-size:11px;height:24px;line-height:16px;padding-left:6px;padding-right:6px}.input.is-medium,.is-medium.textarea{font-size:18px;height:40px;line-height:32px;padding-left:10px;padding-right:10px}.input.is-large,.is-large.textarea{font-size:24px;height:48px;line-height:40px;padding-left:12px;padding-right:12px}.input.is-fullwidth,.is-fullwidth.textarea{display:block;width:100%}.input.is-inline,.is-inline.textarea{display:inline}.textarea{display:block;line-height:1.2;max-height:600px;min-height:120px;min-width:100%;padding:10px;resize:vertical}.checkbox,.radio,.select{display:inline-block;position:relative;vertical-align:top}.checkbox,.radio{cursor:pointer;line-height:16px}.checkbox:hover,.radio:hover{color:#222324}.is-disabled.checkbox,.is-disabled.radio{color:#aeb1b5;pointer-events:none}.is-disabled.checkbox input,.is-disabled.radio input{pointer-events:none}.radio+.radio{margin-left:10px}.select{height:32px}.select select{-webkit-box-align:center;-ms-flex-align:center;align-items:center;background-color:#fff;border:1px solid #d3d6db;border-radius:3px;color:#222324;font-size:14px;height:32px;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start;line-height:24px;padding-left:8px;position:relative;display:block;outline:0;padding-right:36px}.select select.is-active,.select select:active,.select select:focus{border-color:#2077b2;outline:0}.select select.is-disabled,.select select[disabled]{background-color:#f5f7fa;border-color:#d3d6db;cursor:not-allowed;pointer-events:none}.select select.is-disabled::-moz-placeholder,.select select[disabled]::-moz-placeholder{color:rgba(34,35,36,.3)}.select select.is-disabled::-webkit-input-placeholder,.select select[disabled]::-webkit-input-placeholder{color:rgba(34,35,36,.3)}.select select.is-disabled:-moz-placeholder,.select select[disabled]:-moz-placeholder{color:rgba(34,35,36,.3)}.select select.is-disabled:-ms-input-placeholder,.select select[disabled]:-ms-input-placeholder{color:rgba(34,35,36,.3)}.select select.is-white{border-color:#fff}.select select.is-black{border-color:#111}.select select.is-light{border-color:#f5f7fa}.select select.is-dark{border-color:#42464c}.select select.is-info,.select select.is-primary{border-color:#2077b2}.select select.is-success{border-color:#97cd76}.select select.is-warning{border-color:#fce473}.select select.is-danger{border-color:#ed6c63}.select select:hover{border-color:#aeb1b5}.select select::ms-expand{display:none}.help,.label,.select:after{display:block}.select.is-fullwidth,.select.is-fullwidth select{width:100%}.select:after{border:1px solid #2077b2;border-right:0;border-top:0;height:7px;pointer-events:none;position:absolute;-webkit-transform:rotate(-45deg);transform:rotate(-45deg);width:7px;margin-top:-6px;right:16px;top:50%}.select:hover:after{border-color:#222324}.select.is-small{height:24px}.select.is-small select{border-radius:2px;font-size:11px;height:24px;line-height:16px;padding-left:6px;padding-right:28px}.select.is-medium{height:40px}.select.is-medium select{font-size:18px;height:40px;line-height:32px;padding-left:10px;padding-right:44px}.select.is-large{height:48px}.select.is-large select{font-size:24px;height:48px;line-height:40px;padding-left:12px;padding-right:52px}.label{color:#222324}.label:not(:last-child){margin-bottom:5px}.help{font-size:11px;margin-top:5px}.help.is-white{color:#fff}.help.is-black{color:#111}.help.is-light{color:#f5f7fa}.help.is-dark{color:#42464c}.help.is-info,.help.is-primary{color:#2077b2}.help.is-success{color:#97cd76}.help.is-warning{color:#fce473}.help.is-danger{color:#ed6c63}@media screen and (max-width:768px){.control-label{margin-bottom:5px}}@media screen and (min-width:769px){.control-label{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;margin-right:20px;padding-top:7px;text-align:right}}.control{position:relative;text-align:left}.control:not(:last-child){margin-bottom:10px}.control.has-addons{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start}.control.has-addons .button,.control.has-addons .input,.control.has-addons .select,.control.has-addons .textarea{border-radius:0;margin-right:-1px;width:auto}.control.has-addons .button:hover,.control.has-addons .input:hover,.control.has-addons .select:hover,.control.has-addons .textarea:hover{z-index:2}.control.has-addons .button:active,.control.has-addons .button:focus,.control.has-addons .input:active,.control.has-addons .input:focus,.control.has-addons .select:active,.control.has-addons .select:focus,.control.has-addons .textarea:active,.control.has-addons .textarea:focus{z-index:3}.control.has-addons .button:first-child,.control.has-addons .button:first-child select,.control.has-addons .input:first-child,.control.has-addons .input:first-child select,.control.has-addons .select:first-child,.control.has-addons .select:first-child select,.control.has-addons .textarea:first-child,.control.has-addons .textarea:first-child select{border-radius:3px 0 0 3px}.control.has-addons .button:last-child,.control.has-addons .button:last-child select,.control.has-addons .input:last-child,.control.has-addons .input:last-child select,.control.has-addons .select:last-child,.control.has-addons .select:last-child select,.control.has-addons .textarea:last-child,.control.has-addons .textarea:last-child select{border-radius:0 3px 3px 0}.control.has-addons .button.is-expanded,.control.has-addons .input.is-expanded,.control.has-addons .is-expanded.textarea,.control.has-addons .select.is-expanded{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}.control.has-addons.has-addons-centered{-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.control.has-addons.has-addons-right{-webkit-box-pack:end;-ms-flex-pack:end;justify-content:flex-end}.control.has-addons.has-addons-fullwidth .button,.control.has-addons.has-addons-fullwidth .input,.control.has-addons.has-addons-fullwidth .select,.control.has-addons.has-addons-fullwidth .textarea{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}.control.has-icon:not(.has-icon-right) .input,.control.has-icon:not(.has-icon-right) .textarea{padding-left:32px}.control.has-icon:not(.has-icon-right) .input.is-small,.control.has-icon:not(.has-icon-right) .is-small.textarea{padding-left:24px}.control.has-icon:not(.has-icon-right) .input.is-medium,.control.has-icon:not(.has-icon-right) .is-medium.textarea{padding-left:40px}.control.has-icon:not(.has-icon-right) .input.is-large,.control.has-icon:not(.has-icon-right) .is-large.textarea{padding-left:48px}.control.has-icon.has-icon-right .input,.control.has-icon.has-icon-right .textarea{padding-right:32px}.control.has-icon.has-icon-right .input.is-small,.control.has-icon.has-icon-right .is-small.textarea{padding-right:24px}.control.has-icon.has-icon-right .input.is-medium,.control.has-icon.has-icon-right .is-medium.textarea{padding-right:40px}.control.has-icon.has-icon-right .input.is-large,.control.has-icon.has-icon-right .is-large.textarea{padding-right:48px}.control.is-grouped{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start}.control.is-grouped>.control:not(:last-child){margin-bottom:0;margin-right:10px}.control.is-grouped>.control.is-expanded{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}.control.is-grouped.is-grouped-centered{-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.control.is-grouped.is-grouped-right{-webkit-box-pack:end;-ms-flex-pack:end;justify-content:flex-end}@media screen and (min-width:769px){.control.is-horizontal{display:-webkit-box;display:-ms-flexbox;display:flex}.control.is-horizontal>.control{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-flex:5;-ms-flex-positive:5;flex-grow:5}}.control.is-loading:after{position:absolute!important;right:8px;top:8px}.image{display:block;position:relative}.image img{display:block;height:auto;width:100%}.image.is-16by9 img,.image.is-1by1 img,.image.is-2by1 img,.image.is-3by2 img,.image.is-4by3 img,.image.is-square img{bottom:0;left:0;position:absolute;right:0;top:0;height:100%;width:100%}.image.is-1by1,.image.is-square{padding-top:100%}.image.is-4by3{padding-top:75%}.image.is-3by2{padding-top:66.6666%}.image.is-16by9{padding-top:56.25%}.image.is-2by1{padding-top:50%}.image.is-16x16{height:16px;width:16px}.image.is-24x24{height:24px;width:24px}.image.is-32x32{height:32px;width:32px}.image.is-48x48{height:48px;width:48px}.image.is-64x64{height:64px;width:64px}.image.is-96x96{height:96px;width:96px}.image.is-128x128{height:128px;width:128px}.notification{background-color:#f5f7fa;border-radius:3px;padding:16px 20px;position:relative}.notification:after{clear:both;display:table}.notification .delete,.notification .modal-close{border-radius:0 3px;float:right;margin:-16px -20px 0 20px}.notification .subtitle,.notification .title{color:inherit}.notification.is-white{background-color:#fff;color:#111}.notification.is-black{background-color:#111;color:#fff}.notification.is-light{background-color:#f5f7fa;color:#42464c}.notification.is-dark{background-color:#42464c;color:#f5f7fa}.notification.is-info,.notification.is-primary{background-color:#2077b2;color:#fff}.notification.is-success{background-color:#97cd76;color:#fff}.notification.is-warning{background-color:#fce473;color:rgba(17,17,17,.5)}.notification.is-danger{background-color:#ed6c63;color:#fff}.progress{border:none;border-radius:290486px;display:block;height:12px;overflow:hidden;padding:0;width:100%}.progress::-webkit-progress-bar{background-color:#d3d6db}.progress::-webkit-progress-value{background-color:#42464c}.progress::-moz-progress-bar{background-color:#42464c}.progress.is-white::-webkit-progress-value{background-color:#fff}.progress.is-white::-moz-progress-bar{background-color:#fff}.progress.is-black::-webkit-progress-value{background-color:#111}.progress.is-black::-moz-progress-bar{background-color:#111}.progress.is-light::-webkit-progress-value{background-color:#f5f7fa}.progress.is-light::-moz-progress-bar{background-color:#f5f7fa}.progress.is-dark::-webkit-progress-value{background-color:#42464c}.progress.is-dark::-moz-progress-bar{background-color:#42464c}.progress.is-primary::-webkit-progress-value{background-color:#2077b2}.progress.is-primary::-moz-progress-bar{background-color:#2077b2}.progress.is-info::-webkit-progress-value{background-color:#2077b2}.progress.is-info::-moz-progress-bar{background-color:#2077b2}.progress.is-success::-webkit-progress-value{background-color:#97cd76}.progress.is-success::-moz-progress-bar{background-color:#97cd76}.progress.is-warning::-webkit-progress-value{background-color:#fce473}.progress.is-warning::-moz-progress-bar{background-color:#fce473}.progress.is-danger::-webkit-progress-value{background-color:#ed6c63}.progress.is-danger::-moz-progress-bar{background-color:#ed6c63}.progress.is-small{height:8px}.progress.is-medium{height:16px}.progress.is-large{height:20px}.table{background-color:#fff;color:#222324;margin-bottom:20px;width:100%}.table td,.table th{border:1px solid #d3d6db;border-width:0 0 1px;padding:8px 10px;vertical-align:top}.table td.is-icon,.table th.is-icon{padding:5px;display:inline-block;font-size:21px;height:24px;line-height:24px;text-align:center;vertical-align:top;width:24px}.table td.is-icon.is-link,.table th.is-icon.is-link{padding:0}.table td.is-icon.is-link>a,.table th.is-icon.is-link>a{padding:5px}.table td.is-link,.table th.is-link{padding:0}.table td.is-link>a,.table th.is-link>a{display:block;padding:8px 10px}.table td.is-link>a:hover,.table th.is-link>a:hover{background-color:#2077b2;color:#fff}.table td.is-narrow,.table th.is-narrow{white-space:nowrap;width:1%}.table th{color:#222324;text-align:left}.table tr:hover{background-color:#f5f7fa;color:#222324}.table thead td,.table thead th{border-width:0 0 2px;color:#aeb1b5}.table tbody tr:last-child td,.table tbody tr:last-child th{border-bottom-width:0}.table tfoot td,.table tfoot th{border-width:2px 0 0;color:#aeb1b5}.table.is-bordered td,.table.is-bordered th{border-width:1px}.table.is-bordered tr:last-child td,.table.is-bordered tr:last-child th{border-bottom-width:1px}.table.is-narrow td,.table.is-narrow th{padding:5px 10px}.table.is-narrow td.is-icon,.table.is-narrow th.is-icon{padding:2px}.table.is-narrow td.is-icon.is-link,.table.is-narrow th.is-icon.is-link{padding:0}.table.is-narrow td.is-icon.is-link>a,.table.is-narrow th.is-icon.is-link>a{padding:2px}.table.is-narrow td.is-link,.table.is-narrow th.is-link{padding:0}.table.is-narrow td.is-link>a,.table.is-narrow th.is-link>a{padding:5px 10px}.table.is-striped tbody tr:hover{background-color:#eef2f7}.table.is-striped tbody tr:nth-child(2n){background-color:#f5f7fa}.table.is-striped tbody tr:nth-child(2n):hover{background-color:#eef2f7}.subtitle,.title{font-weight:300;word-break:break-word}.subtitle em,.subtitle span,.title em,.title span{font-weight:300}.subtitle a:hover,.title a:hover{border-bottom:1px solid}.subtitle strong,.title strong{font-weight:500}.subtitle .tag,.title .tag{vertical-align:bottom}.delete,.modal-close,.subtitle code{display:inline-block;vertical-align:top}.title{color:#222324}.title code{display:inline-block;font-size:28px}.title strong{color:inherit}.title+.highlight,.title+.subtitle{margin-top:-10px}.title.is-1{font-size:48px}.title.is-1 code,.title.is-2{font-size:40px}.title.is-2 code,.title.is-3{font-size:28px}.title.is-3 code,.title.is-4{font-size:24px}.title.is-4 code,.title.is-5{font-size:18px}.title.is-5 code,.title.is-6,.title.is-6 code{font-size:14px}.title.is-normal{font-weight:400}.title.is-normal strong{font-weight:700}@media screen and (min-width:769px){.title+.subtitle{margin-top:-15px}}.subtitle{font-size:18px;line-height:1.125}.subtitle code{border-radius:3px;font-size:14px;padding:2px 3px}.subtitle strong{color:#222324}.subtitle+.title{margin-top:-20px}.subtitle.is-1{font-size:48px}.subtitle.is-1 code,.subtitle.is-2{font-size:40px}.subtitle.is-2 code,.subtitle.is-3{font-size:28px}.subtitle.is-3 code,.subtitle.is-4{font-size:24px}.subtitle.is-4 code,.subtitle.is-5{font-size:18px}.subtitle.is-5 code,.subtitle.is-6,.subtitle.is-6 code{font-size:14px}.subtitle.is-normal{font-weight:400}.subtitle.is-normal strong{font-weight:700}.delete,.modal-close{background-color:rgba(17,17,17,.2);border:none;border-radius:290486px;cursor:pointer;height:24px;position:relative;width:24px}.delete:after,.delete:before,.modal-close:after,.modal-close:before{background-color:#fff;content:"";display:block;height:2px;left:50%;margin-left:-25%;margin-top:-1px;position:absolute;top:50%;width:50%}.icon,.icon.is-large,.icon.is-medium,.icon.is-small{display:inline-block;vertical-align:top;text-align:center}.delete:before,.modal-close:before{-webkit-transform:rotate(45deg);transform:rotate(45deg)}.delete:after,.modal-close:after{-webkit-transform:rotate(-45deg);transform:rotate(-45deg)}.delete:hover,.modal-close:hover{background-color:rgba(17,17,17,.5)}.delete.is-small,.is-small.modal-close,.tag:not(.is-large) .delete,.tag:not(.is-large) .modal-close{height:16px;width:16px}.delete.is-medium,.is-medium.modal-close{height:32px;width:32px}.delete.is-large,.is-large.modal-close{height:40px;width:40px}.icon{height:24px;width:24px;font-size:inherit;line-height:inherit}.icon.is-small{font-size:14px;height:16px;line-height:16px;width:16px}.icon.is-medium{font-size:28px;height:32px;line-height:32px;width:32px}.icon.is-large{font-size:42px;height:48px;line-height:48px;width:48px}.hamburger,.nav-toggle{cursor:pointer;display:block;height:50px;position:relative;width:50px}.hamburger span,.nav-toggle span{background-color:#42464c;display:block;height:1px;left:50%;margin-left:-7px;position:absolute;top:50%;-webkit-transition:none 86ms ease-out;transition:none 86ms ease-out;-webkit-transition-property:background,left,opacity,-webkit-transform;transition-property:background,left,opacity,-webkit-transform;transition-property:background,left,opacity,transform;transition-property:background,left,opacity,transform,-webkit-transform;width:15px}.card,.card-image{position:relative}.hamburger span:nth-child(1),.nav-toggle span:nth-child(1){margin-top:-6px}.hamburger span:nth-child(2),.nav-toggle span:nth-child(2){margin-top:-1px}.hamburger span:nth-child(3),.nav-toggle span:nth-child(3){margin-top:4px}.hamburger:hover,.nav-toggle:hover{background-color:#f5f7fa}.hamburger.is-active span,.is-active.nav-toggle span{background-color:#2077b2}.hamburger.is-active span:nth-child(1),.is-active.nav-toggle span:nth-child(1){margin-left:-5px;-webkit-transform:rotate(45deg);transform:rotate(45deg);-webkit-transform-origin:left top;transform-origin:left top}.hamburger.is-active span:nth-child(2),.is-active.nav-toggle span:nth-child(2){opacity:0}.hamburger.is-active span:nth-child(3),.is-active.nav-toggle span:nth-child(3){margin-left:-5px;-webkit-transform:rotate(-45deg);transform:rotate(-45deg);-webkit-transform-origin:left bottom;transform-origin:left bottom}.heading{display:block;font-size:11px;margin-bottom:5px}.highlight{font-size:12px;font-weight:400;overflow:hidden;padding:0}.highlight pre{overflow:auto}.button.is-loading:after,.control.is-loading:after,.loader{-webkit-animation:spin-around .5s infinite linear;animation:spin-around .5s infinite linear;border:2px solid #d3d6db;border-radius:290486px;border-right-color:transparent;border-top-color:transparent;content:"";display:block;height:16px;position:relative;width:16px}.number,.tag{background-color:#f5f7fa;border-radius:290486px;vertical-align:top}.number{display:inline-block;font-size:18px}.tag{-webkit-box-align:center;-ms-flex-align:center;align-items:center;color:#42464c;display:-webkit-inline-box;display:-ms-inline-flexbox;display:inline-flex;font-size:12px;height:24px;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;line-height:16px;padding-left:10px;padding-right:10px}.tag .delete,.tag .modal-close{margin-left:4px;margin-right:-6px}.tag.is-white{background-color:#fff;color:#111}.tag.is-black{background-color:#111;color:#fff}.tag.is-light{background-color:#f5f7fa;color:#42464c}.tag.is-dark{background-color:#42464c;color:#f5f7fa}.tag.is-info,.tag.is-primary{background-color:#2077b2;color:#fff}.tag.is-success{background-color:#97cd76;color:#fff}.tag.is-warning{background-color:#fce473;color:rgba(17,17,17,.5)}.tag.is-danger{background-color:#ed6c63;color:#fff}.tag.is-small{font-size:11px;height:20px;padding-left:8px;padding-right:8px}.tag.is-medium{font-size:14px;height:32px;padding-left:14px;padding-right:14px}.media-number,.tag.is-large{font-size:18px;line-height:24px}.tag.is-large{height:40px;padding-left:18px;padding-right:18px}.tag.is-large .delete,.tag.is-large .modal-close{margin-left:4px;margin-right:-8px}.button,.delete,.is-unselectable,.modal-close,.tabs,.unselectable{-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.card-header{-webkit-box-align:stretch;-ms-flex-align:stretch;align-items:stretch;box-shadow:0 1px 2px rgba(17,17,17,.1);display:flex;min-height:40px}.card-header-title{-webkit-box-align:start;-ms-flex-align:start;align-items:flex-start;color:#222324;display:flex;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;font-weight:700;padding:10px}.card-header-icon{-webkit-box-align:center;-ms-flex-align:center;align-items:center;cursor:pointer;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;width:40px}.card-image{display:block}.card-content{padding:20px}.card-content .title+.subtitle{margin-top:-20px}.card-footer{border-top:1px solid #d3d6db;-webkit-box-align:stretch;-ms-flex-align:stretch;align-items:stretch;display:flex}.media .media,.media+.media{border-top:1px solid rgba(211,214,219,.5)}.card-footer-item{-webkit-box-align:center;-ms-flex-align:center;align-items:center;display:flex;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;padding:10px}.card-footer-item:not(:last-child){border-right:1px solid #d3d6db}.card{background-color:#fff;box-shadow:0 2px 3px rgba(17,17,17,.1),0 0 0 1px rgba(17,17,17,.1);color:#42464c;width:300px}.card .media:not(:last-child){margin-bottom:10px}.card.is-fullwidth{width:100%}.card.is-rounded{border-radius:5px}.column{-ms-flex-preferred-size:0;flex-basis:0;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;-ms-flex-negative:1;flex-shrink:1;padding:10px}.columns.is-mobile>.column.is-narrow{-webkit-box-flex:0;-ms-flex:none;flex:none}.columns.is-mobile>.column.is-full{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.columns.is-mobile>.column.is-three-quarters{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.columns.is-mobile>.column.is-two-thirds{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.6666%}.columns.is-mobile>.column.is-half{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.columns.is-mobile>.column.is-one-third{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.3333%}.columns.is-mobile>.column.is-one-quarter{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.columns.is-mobile>.column.is-offset-three-quarters{margin-left:75%}.columns.is-mobile>.column.is-offset-two-thirds{margin-left:66.6666%}.columns.is-mobile>.column.is-offset-half{margin-left:50%}.columns.is-mobile>.column.is-offset-one-third{margin-left:33.3333%}.columns.is-mobile>.column.is-offset-one-quarter{margin-left:25%}.columns.is-mobile>.column.is-1{-webkit-box-flex:0;-ms-flex:none;flex:none;width:8.33333%}.columns.is-mobile>.column.is-offset-1{margin-left:8.33333%}.columns.is-mobile>.column.is-2{-webkit-box-flex:0;-ms-flex:none;flex:none;width:16.66667%}.columns.is-mobile>.column.is-offset-2{margin-left:16.66667%}.columns.is-mobile>.column.is-3{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.columns.is-mobile>.column.is-offset-3{margin-left:25%}.columns.is-mobile>.column.is-4{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.33333%}.columns.is-mobile>.column.is-offset-4{margin-left:33.33333%}.columns.is-mobile>.column.is-5{-webkit-box-flex:0;-ms-flex:none;flex:none;width:41.66667%}.columns.is-mobile>.column.is-offset-5{margin-left:41.66667%}.columns.is-mobile>.column.is-6{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.columns.is-mobile>.column.is-offset-6{margin-left:50%}.columns.is-mobile>.column.is-7{-webkit-box-flex:0;-ms-flex:none;flex:none;width:58.33333%}.columns.is-mobile>.column.is-offset-7{margin-left:58.33333%}.columns.is-mobile>.column.is-8{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.66667%}.columns.is-mobile>.column.is-offset-8{margin-left:66.66667%}.columns.is-mobile>.column.is-9{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.columns.is-mobile>.column.is-offset-9{margin-left:75%}.columns.is-mobile>.column.is-10{-webkit-box-flex:0;-ms-flex:none;flex:none;width:83.33333%}.columns.is-mobile>.column.is-offset-10{margin-left:83.33333%}.columns.is-mobile>.column.is-11{-webkit-box-flex:0;-ms-flex:none;flex:none;width:91.66667%}.columns.is-mobile>.column.is-offset-11{margin-left:91.66667%}.columns.is-mobile>.column.is-12{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.columns.is-mobile>.column.is-offset-12{margin-left:100%}@media screen and (max-width:768px){.column.is-narrow-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none}.column.is-full-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.column.is-three-quarters-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.column.is-two-thirds-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.6666%}.column.is-half-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.column.is-one-third-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.3333%}.column.is-one-quarter-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.column.is-offset-three-quarters-mobile{margin-left:75%}.column.is-offset-two-thirds-mobile{margin-left:66.6666%}.column.is-offset-half-mobile{margin-left:50%}.column.is-offset-one-third-mobile{margin-left:33.3333%}.column.is-offset-one-quarter-mobile{margin-left:25%}.column.is-1-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:8.33333%}.column.is-offset-1-mobile{margin-left:8.33333%}.column.is-2-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:16.66667%}.column.is-offset-2-mobile{margin-left:16.66667%}.column.is-3-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.column.is-offset-3-mobile{margin-left:25%}.column.is-4-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.33333%}.column.is-offset-4-mobile{margin-left:33.33333%}.column.is-5-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:41.66667%}.column.is-offset-5-mobile{margin-left:41.66667%}.column.is-6-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.column.is-offset-6-mobile{margin-left:50%}.column.is-7-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:58.33333%}.column.is-offset-7-mobile{margin-left:58.33333%}.column.is-8-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.66667%}.column.is-offset-8-mobile{margin-left:66.66667%}.column.is-9-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.column.is-offset-9-mobile{margin-left:75%}.column.is-10-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:83.33333%}.column.is-offset-10-mobile{margin-left:83.33333%}.column.is-11-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:91.66667%}.column.is-offset-11-mobile{margin-left:91.66667%}.column.is-12-mobile{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.column.is-offset-12-mobile{margin-left:100%}}@media screen and (min-width:769px){.column.is-narrow,.column.is-narrow-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none}.column.is-full,.column.is-full-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.column.is-three-quarters,.column.is-three-quarters-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.column.is-two-thirds,.column.is-two-thirds-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.6666%}.column.is-half,.column.is-half-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.column.is-one-third,.column.is-one-third-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.3333%}.column.is-one-quarter,.column.is-one-quarter-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.column.is-offset-three-quarters,.column.is-offset-three-quarters-tablet{margin-left:75%}.column.is-offset-two-thirds,.column.is-offset-two-thirds-tablet{margin-left:66.6666%}.column.is-offset-half,.column.is-offset-half-tablet{margin-left:50%}.column.is-offset-one-third,.column.is-offset-one-third-tablet{margin-left:33.3333%}.column.is-offset-one-quarter,.column.is-offset-one-quarter-tablet{margin-left:25%}.column.is-1,.column.is-1-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:8.33333%}.column.is-offset-1,.column.is-offset-1-tablet{margin-left:8.33333%}.column.is-2,.column.is-2-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:16.66667%}.column.is-offset-2,.column.is-offset-2-tablet{margin-left:16.66667%}.column.is-3,.column.is-3-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.column.is-offset-3,.column.is-offset-3-tablet{margin-left:25%}.column.is-4,.column.is-4-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.33333%}.column.is-offset-4,.column.is-offset-4-tablet{margin-left:33.33333%}.column.is-5,.column.is-5-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:41.66667%}.column.is-offset-5,.column.is-offset-5-tablet{margin-left:41.66667%}.column.is-6,.column.is-6-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.column.is-offset-6,.column.is-offset-6-tablet{margin-left:50%}.column.is-7,.column.is-7-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:58.33333%}.column.is-offset-7,.column.is-offset-7-tablet{margin-left:58.33333%}.column.is-8,.column.is-8-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.66667%}.column.is-offset-8,.column.is-offset-8-tablet{margin-left:66.66667%}.column.is-9,.column.is-9-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.column.is-offset-9,.column.is-offset-9-tablet{margin-left:75%}.column.is-10,.column.is-10-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:83.33333%}.column.is-offset-10,.column.is-offset-10-tablet{margin-left:83.33333%}.column.is-11,.column.is-11-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:91.66667%}.column.is-offset-11,.column.is-offset-11-tablet{margin-left:91.66667%}.column.is-12,.column.is-12-tablet{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.column.is-offset-12,.column.is-offset-12-tablet{margin-left:100%}}@media screen and (min-width:980px){.column.is-narrow-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none}.column.is-full-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.column.is-three-quarters-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.column.is-two-thirds-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.6666%}.column.is-half-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.column.is-one-third-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.3333%}.column.is-one-quarter-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.column.is-offset-three-quarters-desktop{margin-left:75%}.column.is-offset-two-thirds-desktop{margin-left:66.6666%}.column.is-offset-half-desktop{margin-left:50%}.column.is-offset-one-third-desktop{margin-left:33.3333%}.column.is-offset-one-quarter-desktop{margin-left:25%}.column.is-1-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:8.33333%}.column.is-offset-1-desktop{margin-left:8.33333%}.column.is-2-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:16.66667%}.column.is-offset-2-desktop{margin-left:16.66667%}.column.is-3-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.column.is-offset-3-desktop{margin-left:25%}.column.is-4-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.33333%}.column.is-offset-4-desktop{margin-left:33.33333%}.column.is-5-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:41.66667%}.column.is-offset-5-desktop{margin-left:41.66667%}.column.is-6-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.column.is-offset-6-desktop{margin-left:50%}.column.is-7-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:58.33333%}.column.is-offset-7-desktop{margin-left:58.33333%}.column.is-8-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.66667%}.column.is-offset-8-desktop{margin-left:66.66667%}.column.is-9-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.column.is-offset-9-desktop{margin-left:75%}.column.is-10-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:83.33333%}.column.is-offset-10-desktop{margin-left:83.33333%}.column.is-11-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:91.66667%}.column.is-offset-11-desktop{margin-left:91.66667%}.column.is-12-desktop{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.column.is-offset-12-desktop{margin-left:100%}}@media screen and (min-width:1180px){.column.is-narrow-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none}.column.is-full-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.column.is-three-quarters-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.column.is-two-thirds-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.6666%}.column.is-half-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.column.is-one-third-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.3333%}.column.is-one-quarter-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.column.is-offset-three-quarters-widescreen{margin-left:75%}.column.is-offset-two-thirds-widescreen{margin-left:66.6666%}.column.is-offset-half-widescreen{margin-left:50%}.column.is-offset-one-third-widescreen{margin-left:33.3333%}.column.is-offset-one-quarter-widescreen{margin-left:25%}.column.is-1-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:8.33333%}.column.is-offset-1-widescreen{margin-left:8.33333%}.column.is-2-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:16.66667%}.column.is-offset-2-widescreen{margin-left:16.66667%}.column.is-3-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.column.is-offset-3-widescreen{margin-left:25%}.column.is-4-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.33333%}.column.is-offset-4-widescreen{margin-left:33.33333%}.column.is-5-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:41.66667%}.column.is-offset-5-widescreen{margin-left:41.66667%}.column.is-6-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.column.is-offset-6-widescreen{margin-left:50%}.column.is-7-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:58.33333%}.column.is-offset-7-widescreen{margin-left:58.33333%}.column.is-8-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.66667%}.column.is-offset-8-widescreen{margin-left:66.66667%}.column.is-9-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.column.is-offset-9-widescreen{margin-left:75%}.column.is-10-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:83.33333%}.column.is-offset-10-widescreen{margin-left:83.33333%}.column.is-11-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:91.66667%}.column.is-offset-11-widescreen{margin-left:91.66667%}.column.is-12-widescreen{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}.column.is-offset-12-widescreen{margin-left:100%}}.columns{margin-left:-10px;margin-right:-10px;margin-top:-10px}.columns:last-child{margin-bottom:-10px}.columns:not(:last-child){margin-bottom:10px}.columns.is-centered{-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.columns.is-gapless{margin-left:0;margin-right:0;margin-top:0}.columns.is-gapless:last-child{margin-bottom:0}.columns.is-gapless:not(:last-child){margin-bottom:20px}.columns.is-gapless>.column{margin:0;padding:0}@media screen and (min-width:769px){.columns.is-grid{-ms-flex-wrap:wrap;flex-wrap:wrap}.columns.is-grid>.column{max-width:33.3333%;padding:10px;width:33.3333%}.columns.is-grid>.column+.column{margin-left:0}}.columns.is-mobile{display:-webkit-box;display:-ms-flexbox;display:flex}.columns.is-multiline{-ms-flex-wrap:wrap;flex-wrap:wrap}.columns.is-vcentered{-webkit-box-align:center;-ms-flex-align:center;-ms-grid-row-align:center;align-items:center}.nav-left,.tile{-webkit-box-align:stretch}@media screen and (min-width:769px){.columns:not(.is-desktop){display:-webkit-box;display:-ms-flexbox;display:flex}}@media screen and (min-width:980px){.columns.is-desktop{display:-webkit-box;display:-ms-flexbox;display:flex}}.tile{-ms-flex-align:stretch;-ms-grid-row-align:stretch;align-items:stretch;-ms-flex-preferred-size:auto;flex-basis:auto;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;-ms-flex-negative:1;flex-shrink:1;min-height:-webkit-min-content;min-height:-moz-min-content;min-height:min-content}.level,.modal{-ms-grid-row-align:center}.tile.is-ancestor{margin-left:-10px;margin-right:-10px;margin-top:-10px}.tile.is-ancestor:last-child{margin-bottom:-10px}.tile.is-ancestor:not(:last-child){margin-bottom:10px}.tile.is-child{margin:0!important}.level-left .level-item:not(:last-child),.level-right .level-item:not(:last-child),.media-left{margin-right:10px}.tile.is-parent{padding:10px}.tile.is-vertical{-ms-flex-direction:column;flex-direction:column}.tile.is-vertical>.tile.is-child:not(:last-child){margin-bottom:20px!important}@media screen and (min-width:769px){.tile:not(.is-child){display:-webkit-box;display:-ms-flexbox;display:flex}.tile.is-1{-webkit-box-flex:0;-ms-flex:none;flex:none;width:8.33333%}.tile.is-2{-webkit-box-flex:0;-ms-flex:none;flex:none;width:16.66667%}.tile.is-3{-webkit-box-flex:0;-ms-flex:none;flex:none;width:25%}.tile.is-4{-webkit-box-flex:0;-ms-flex:none;flex:none;width:33.33333%}.tile.is-5{-webkit-box-flex:0;-ms-flex:none;flex:none;width:41.66667%}.tile.is-6{-webkit-box-flex:0;-ms-flex:none;flex:none;width:50%}.tile.is-7{-webkit-box-flex:0;-ms-flex:none;flex:none;width:58.33333%}.tile.is-8{-webkit-box-flex:0;-ms-flex:none;flex:none;width:66.66667%}.tile.is-9{-webkit-box-flex:0;-ms-flex:none;flex:none;width:75%}.tile.is-10{-webkit-box-flex:0;-ms-flex:none;flex:none;width:83.33333%}.tile.is-11{-webkit-box-flex:0;-ms-flex:none;flex:none;width:91.66667%}.tile.is-12{-webkit-box-flex:0;-ms-flex:none;flex:none;width:100%}}.highlight{background-color:#fdf6e3;color:#586e75}.highlight .c{color:#93a1a1}.highlight .err,.highlight .g{color:#586e75}.highlight .k{color:#859900}.highlight .l,.highlight .n{color:#586e75}.highlight .o{color:#859900}.highlight .x{color:#cb4b16}.highlight .p{color:#586e75}.highlight .cm{color:#93a1a1}.highlight .cp{color:#859900}.highlight .c1{color:#93a1a1}.highlight .cs{color:#859900}.highlight .gd{color:#2aa198}.highlight .ge{color:#586e75;font-style:italic}.highlight .gr{color:#dc322f}.highlight .gh{color:#cb4b16}.highlight .gi{color:#859900}.highlight .go,.highlight .gp{color:#586e75}.highlight .gs{color:#586e75;font-weight:700}.highlight .gu{color:#cb4b16}.highlight .gt{color:#586e75}.highlight .kc{color:#cb4b16}.highlight .kd{color:#268bd2}.highlight .kn,.highlight .kp{color:#859900}.highlight .kr{color:#268bd2}.highlight .kt{color:#dc322f}.highlight .ld{color:#586e75}.highlight .m,.highlight .s{color:#2aa198}.highlight .na{color:#B58900}.highlight .nb{color:#586e75}.highlight .nc{color:#268bd2}.highlight .no{color:#cb4b16}.highlight .nd{color:#268bd2}.highlight .ne,.highlight .ni{color:#cb4b16}.highlight .nf{color:#268bd2}.highlight .nl,.highlight .nn,.highlight .nx,.highlight .py{color:#586e75}.highlight .nt,.highlight .nv{color:#268bd2}.highlight .ow{color:#859900}.highlight .w{color:#586e75}.highlight .mf,.highlight .mh,.highlight .mi,.highlight .mo{color:#2aa198}.highlight .sb{color:#93a1a1}.highlight .sc{color:#2aa198}.highlight .sd{color:#586e75}.highlight .s2{color:#2aa198}.highlight .se{color:#cb4b16}.highlight .sh{color:#586e75}.highlight .si,.highlight .sx{color:#2aa198}.highlight .sr{color:#dc322f}.highlight .s1,.highlight .ss{color:#2aa198}.highlight .bp,.highlight .vc,.highlight .vg,.highlight .vi{color:#268bd2}.highlight .il{color:#2aa198}.level-item .subtitle,.level-item .title{margin-bottom:0}.level-left .level-item.is-flexible,.level-right .level-item.is-flexible{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}@media screen and (max-width:768px){.level-item:not(:last-child){margin-bottom:10px}.level-left+.level-right{margin-top:20px}}@media screen and (min-width:769px){.level-left{-webkit-box-align:center;-ms-flex-align:center;align-items:center;display:-webkit-box;display:-ms-flexbox;display:flex}.level-right{-webkit-box-align:center;-ms-flex-align:center;align-items:center;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:end;-ms-flex-pack:end;justify-content:flex-end}}.level{-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:justify;-ms-flex-pack:justify;justify-content:space-between}.level code{border-radius:3px}.level img{display:inline-block;vertical-align:top}.level.is-mobile{display:flex}.level.is-mobile>.level-item:not(:last-child){margin-bottom:0}.level.is-mobile>.level-item:not(.is-narrow){-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}@media screen and (min-width:769px){.level{display:-webkit-box;display:-ms-flexbox;display:flex}.level>.level-item:not(.is-narrow){-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}.media-number{margin-right:10px}.media.is-large .media-number{margin-right:20px}}.media-number{background-color:#f5f7fa;border-radius:290486px;display:inline-block;height:32px;min-width:32px;padding:4px 8px;text-align:center;vertical-align:top}@media screen and (max-width:768px){.media-number{margin-bottom:10px}}.media-right{margin-left:10px}.media-content{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;text-align:left}.media{-webkit-box-align:start;-ms-flex-align:start;align-items:flex-start;display:flex;text-align:left}.nav,.pagination,.panel-icon{text-align:center}.media .content:not(:last-child){margin-bottom:10px}.media .media{display:flex;padding-top:10px}.media .media .content:not(:last-child),.media .media .control:not(:last-child){margin-bottom:5px}.media .media .media{padding-top:5px}.media .media .media+.media{margin-top:5px}.media+.media{margin-top:10px;padding-top:10px}.media.is-large+.media{margin-top:20px;padding-top:20px}.menu-list a,.menu-nav a{display:block;padding:5px 10px}.menu-list a{border-radius:2px;color:#42464c}.menu-list a:hover{background-color:#f5f7fa;color:#2077b2}.menu-list a.is-active{background-color:#2077b2;color:#fff}.menu-list li ul{border-left:1px solid #d3d6db;margin:10px;padding-left:10px}.menu-label{color:#aeb1b5;font-size:11px;margin-bottom:5px}.menu-label:not(:first-child){margin-top:20px}.message-body{border:1px solid #d3d6db;border-radius:3px;padding:12px 15px}.message-body strong{color:inherit}.message-header{background-color:#42464c;border-radius:3px 3px 0 0;color:#fff;padding:7px 10px}.message-header strong{color:inherit}.message-header+.message-body{border-radius:0 0 3px 3px;border-top:none}.message{background-color:#f5f7fa;border-radius:3px}.message.is-white{background-color:#fff}.message.is-white .message-header{background-color:#fff;color:#111}.message.is-white .message-body{border-color:#fff;color:#666}.message.is-black{background-color:#f5f5f5}.message.is-black .message-header{background-color:#111;color:#fff}.message.is-black .message-body{border-color:#111;color:gray}.message.is-light{background-color:#f5f7fa}.message.is-light .message-header{background-color:#f5f7fa;color:#42464c}.message.is-light .message-body{border-color:#f5f7fa;color:#666}.message.is-dark{background-color:#f4f5f6}.message.is-dark .message-header{background-color:#42464c;color:#f5f7fa}.message.is-dark .message-body{border-color:#42464c;color:gray}.message.is-primary{background-color:#eef6fc}.message.is-primary .message-header{background-color:#2077b2;color:#fff}.message.is-primary .message-body{border-color:#2077b2;color:gray}.message.is-info{background-color:#eef6fc}.message.is-info .message-header{background-color:#2077b2;color:#fff}.message.is-info .message-body{border-color:#2077b2;color:gray}.message.is-success{background-color:#f4faf0}.message.is-success .message-header{background-color:#97cd76;color:#fff}.message.is-success .message-body{border-color:#97cd76;color:gray}.message.is-warning{background-color:#fffbeb}.message.is-warning .message-header{background-color:#fce473;color:rgba(17,17,17,.5)}.message.is-warning .message-body{border-color:#fce473;color:#666}.message.is-danger{background-color:#fdeeed}.message.is-danger .message-header{background-color:#ed6c63;color:#fff}.message.is-danger .message-body{border-color:#ed6c63;color:gray}.modal-background{bottom:0;left:0;position:absolute;right:0;top:0;background-color:rgba(17,17,17,.86)}.modal-card,.modal-content{margin:0 20px;max-height:calc(100vh - 160px);overflow:auto;position:relative;width:100%}@media screen and (min-width:769px){.modal-card,.modal-content{margin:0 auto;max-height:calc(100vh - 40px);width:640px}}.modal-close{background:0 0;height:40px;position:fixed;right:20px;top:20px;width:40px}.hero-video,.modal{bottom:0;left:0;right:0}.modal-card{background-color:#fff;border-radius:5px;display:flex;-ms-flex-direction:column;flex-direction:column;max-height:calc(100vh - 40px);overflow:hidden}.modal-card-foot,.modal-card-head{-webkit-box-align:center;-ms-flex-align:center;align-items:center;background-color:#f5f7fa;display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-negative:0;flex-shrink:0;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start;padding:20px;position:relative}.modal-card-head{border-bottom:1px solid #d3d6db}.modal-card-title{color:#222324;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;font-size:24px;line-height:1}.modal-card-foot{border-top:1px solid #d3d6db}.modal-card-foot .button:not(:last-child){margin-right:10px}.modal-card-body{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;overflow:auto;padding:20px}.modal,.nav-left,.tabs{overflow:hidden}.nav-left,.tabs{overflow-x:auto}.modal{top:0;-webkit-box-align:center;-ms-flex-align:center;align-items:center;display:none;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;position:fixed;z-index:1986}.nav-item,.pagination{-webkit-box-align:center}.modal.is-active{display:-webkit-box;display:-ms-flexbox;display:flex}@media screen and (min-width:769px){.nav-toggle{display:none}}.level-item{stroke:currentColor;fill:none;position:relative;top:.1111111111111111em}.nav-item{-ms-flex-align:center;align-items:center;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;padding:10px}.nav-item a{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}.nav-item img{max-height:24px}.nav-item .button+.button{margin-left:10px}.nav-item .tag:first-child{margin-right:5px}.nav-item .tag:last-child{margin-left:5px}.nav-item a,a.nav-item{color:#42464c}.nav-item a.is-active,.nav-item a:hover,a.nav-item.is-active,a.nav-item:hover{color:#222324}.nav-item a.is-tab,a.nav-item.is-tab{border-bottom:1px solid transparent;border-top:1px solid transparent;padding-left:12px;padding-right:12px}.nav-item a.is-tab:hover,a.nav-item.is-tab:hover{border-bottom:1px solid #2077b2;border-top:1px solid transparent}.nav-item a.is-tab.is-active,a.nav-item.is-tab.is-active{border-bottom:3px solid #2077b2;border-top:3px solid transparent;color:#2077b2}.panel-heading,.panel-tabs a{border-bottom:1px solid #d3d6db}@media screen and (max-width:768px){.nav-item{-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start}.nav-menu{background-color:#fff;box-shadow:0 4px 7px rgba(17,17,17,.1);left:0;display:none;right:0;top:100%;position:absolute}.nav-menu .nav-item{border-top:1px solid rgba(211,214,219,.5);padding:10px}.nav-menu.is-active{display:block}}.container>.nav>.nav-left>.nav-item:first-child:not(.is-tab),.nav>.container>.nav-left>.nav-item:first-child:not(.is-tab){padding-left:0}@media screen and (min-width:769px) and (max-width:979px){.nav-menu{padding-right:20px}}.container>.nav>.nav-right>.nav-item:last-child:not(.is-tab),.nav>.container>.nav-right>.nav-item:last-child:not(.is-tab){padding-right:0}.nav-left{-ms-flex-align:stretch;align-items:stretch;display:flex;-ms-flex-preferred-size:0;flex-basis:0;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start}.nav,.nav-center{-webkit-box-align:stretch}.nav-center{-ms-flex-align:stretch;align-items:stretch;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;margin-left:auto;margin-right:auto}@media screen and (min-width:769px){.nav-right{-webkit-box-align:stretch;-ms-flex-align:stretch;align-items:stretch;display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-preferred-size:0;flex-basis:0;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;-webkit-box-pack:end;-ms-flex-pack:end;justify-content:flex-end}}.nav,.nav>.container{min-height:50px}.nav{-ms-flex-align:stretch;align-items:stretch;background-color:#fff;display:flex;position:relative;z-index:2}.panel-heading,.tabs.is-boxed a:hover,a.panel-block:hover{background-color:#f5f7fa}.nav>.container{-webkit-box-align:stretch;-ms-flex-align:stretch;align-items:stretch;display:flex;width:100%}.nav.has-shadow{box-shadow:0 2px 3px rgba(17,17,17,.1)}@media screen and (max-width:979px){.container>.nav>.nav-left>.nav-item.is-brand:first-child,.nav>.container>.nav-left>.nav-item.is-brand:first-child{padding-left:20px}}.pagination{-ms-flex-align:center;align-items:center;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.pagination ul,.tabs a{-webkit-box-align:center}.pagination a{display:block;min-width:32px;padding:3px 8px}.pagination span{color:#aeb1b5;display:block;margin:0 4px}.pagination li{margin:0 2px}.pagination ul{-ms-flex-align:center;align-items:center;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}@media screen and (max-width:768px){.pagination{-ms-flex-wrap:wrap;flex-wrap:wrap}.pagination>a{width:calc(50% - 5px)}.pagination>a:not(:first-child){margin-left:10px}.pagination li{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}.pagination ul{margin-top:10px}}@media screen and (min-width:769px){.pagination>a:not(:first-child){-webkit-box-ordinal-group:2;-ms-flex-order:1;order:1}}.panel-icon{display:inline-block;height:16px;vertical-align:top;width:16px;color:#aeb1b5;margin:0 4px 0 -2px;font-size:inherit;line-height:inherit}.panel-heading{border-radius:4px 4px 0 0;color:#222324;font-size:18px;font-weight:300;padding:10px}.panel-tabs,.tabs.is-small{font-size:11px}.panel-list a{color:#42464c}.panel-list a:hover{color:#2077b2}.panel-tabs{display:flex;padding:5px 10px 0;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.panel-tabs a{margin-bottom:-1px;padding:5px}.panel-tabs a.is-active{border-bottom-color:#222324;color:#222324}.panel-block:not(:last-child),.panel-tabs:not(:last-child),.tabs a{border-bottom:1px solid #d3d6db}.panel-block{color:#222324;display:block;line-height:16px;padding:10px}.panel{border:1px solid #d3d6db;border-radius:5px}.panel:not(:last-child){margin-bottom:20px}.tabs{-webkit-box-align:stretch;-ms-flex-align:stretch;align-items:stretch;display:flex;-webkit-box-pack:justify;-ms-flex-pack:justify;justify-content:space-between;line-height:24px}.tabs a{-ms-flex-align:center;align-items:center;color:#42464c;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;margin-bottom:-1px;padding:6px 12px;vertical-align:top}.tabs ul.is-center,.tabs ul.is-left{padding-right:10px}.tabs.is-boxed a,.tabs.is-toggle a{padding-bottom:5px;padding-top:5px}.tabs a:hover{border-bottom-color:#222324;color:#222324}.tabs li{display:block}.tabs li.is-active a{border-bottom-color:#2077b2;color:#2077b2}.tabs ul{-webkit-box-align:center;-ms-flex-align:center;align-items:center;border-bottom:1px solid #d3d6db;display:flex;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start}.tabs ul.is-center{-webkit-box-flex:0;-ms-flex:none;flex:none;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;padding-left:10px}.tabs ul.is-right{-webkit-box-pack:end;-ms-flex-pack:end;justify-content:flex-end;padding-left:10px}.tabs .icon:first-child{margin-right:8px}.tabs .icon:last-child{margin-left:8px}.tabs.is-centered ul{-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.tabs.is-right ul{-webkit-box-pack:end;-ms-flex-pack:end;justify-content:flex-end}.tabs.is-boxed a{border:1px solid transparent;border-radius:3px 3px 0 0}.tabs.is-boxed a:hover{border-bottom-color:#d3d6db}.tabs.is-boxed li.is-active a{background-color:#fff;border-color:#d3d6db;border-bottom-color:transparent!important}.tabs.is-fullwidth li{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}.tabs.is-toggle a{border:1px solid #d3d6db;margin-bottom:0;position:relative}.tabs.is-toggle a:hover{background-color:#f5f7fa;border-color:#aeb1b5;z-index:2}.tabs.is-toggle li+li{margin-left:-1px}.tabs.is-toggle li:first-child a{border-radius:3px 0 0 3px}.tabs.is-toggle li:last-child a{border-radius:0 3px 3px 0}.tabs.is-toggle li.is-active a{background-color:#2077b2;border-color:#2077b2;color:#fff;z-index:1}.hero .tabs ul,.tabs.is-toggle ul{border-bottom:none}.tabs.is-small a{padding:2px 8px}.tabs.is-small.is-boxed a,.tabs.is-small.is-toggle a{padding-bottom:1px;padding-top:1px}.tabs.is-medium{font-size:18px}.tabs.is-medium a{padding:10px 16px}.tabs.is-medium.is-boxed a,.tabs.is-medium.is-toggle a{padding-bottom:9px;padding-top:9px}.tabs.is-large{font-size:28px}.tabs.is-large a{padding:14px 20px}.tabs.is-large.is-boxed a,.tabs.is-large.is-toggle a{padding-bottom:13px;padding-top:13px}.hero-video{position:absolute;top:0;overflow:hidden}.hero-video video{left:50%;min-height:100%;min-width:100%;position:absolute;top:50%;-webkit-transform:translate3d(-50%,-50%,0);transform:translate3d(-50%,-50%,0)}.hero-video.is-transparent{opacity:.3}.hero-buttons{margin-top:20px}@media screen and (max-width:768px){.hero-video{display:none}.hero-buttons .button{display:-webkit-box;display:-ms-flexbox;display:flex}.hero-buttons .button:not(:last-child){margin-bottom:10px}}@media screen and (min-width:769px){.hero-buttons{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.hero-buttons .button:not(:last-child){margin-right:20px}}.hero-foot,.hero-head{-ms-flex-negative:0;flex-shrink:0}.hero-body{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;padding:40px 20px}@media screen and (min-width:980px){.hero-body{padding-left:0;padding-right:0}}.hero{-webkit-box-align:stretch;-ms-flex-align:stretch;align-items:stretch;background-color:#fff;display:flex;-ms-flex-direction:column;flex-direction:column;-webkit-box-pack:justify;-ms-flex-pack:justify;justify-content:space-between}.hero .nav{background:0 0}.hero.is-white{background-color:#fff;color:#111}.hero.is-white .title{color:#111}.hero.is-white .title a,.hero.is-white .title strong{color:inherit}.hero.is-white .subtitle{color:rgba(17,17,17,.7)}.hero.is-white .subtitle a,.hero.is-white .subtitle strong{color:#111}.hero.is-white .nav{box-shadow:0 1px 0 rgba(17,17,17,.2)}@media screen and (max-width:768px){.hero.is-white .nav-menu{background-color:#fff}}.hero.is-white .nav-item a:not(.button),.hero.is-white a.nav-item{color:rgba(17,17,17,.5)}.hero.is-white .nav-item a:not(.button).is-active,.hero.is-white .nav-item a:not(.button):hover,.hero.is-white .tabs.is-boxed a,.hero.is-white .tabs.is-toggle a,.hero.is-white a.nav-item.is-active,.hero.is-white a.nav-item:hover{color:#111}.hero.is-white .tabs a{color:#111;opacity:.5}.hero.is-white .tabs a:hover,.hero.is-white .tabs li.is-active a{opacity:1}.hero.is-white .tabs.is-boxed a:hover,.hero.is-white .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-white .tabs.is-boxed li.is-active a,.hero.is-white .tabs.is-boxed li.is-active a:hover,.hero.is-white .tabs.is-toggle li.is-active a,.hero.is-white .tabs.is-toggle li.is-active a:hover{background-color:#111;border-color:#111;color:#fff}.hero.is-white.is-bold{background-image:-webkit-linear-gradient(309deg,#e6e6e6 0,#fff 71%,#fff 100%);background-image:linear-gradient(141deg,#e6e6e6 0,#fff 71%,#fff 100%)}@media screen and (max-width:768px){.hero.is-white .nav-toggle span{background-color:#111}.hero.is-white .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-black .nav-menu,.hero.is-white .nav-toggle.is-active span{background-color:#111}.hero.is-white .nav-menu .nav-item{border-top-color:rgba(17,17,17,.2)}}.hero.is-black{background-color:#111;color:#fff}.hero.is-black .title{color:#fff}.hero.is-black .title a,.hero.is-black .title strong{color:inherit}.hero.is-black .subtitle{color:rgba(255,255,255,.7)}.hero.is-black .subtitle a,.hero.is-black .subtitle strong{color:#fff}.hero.is-black .nav{box-shadow:0 1px 0 rgba(255,255,255,.2)}.hero.is-black .nav-item a:not(.button),.hero.is-black a.nav-item{color:rgba(255,255,255,.5)}.hero.is-black .nav-item a:not(.button).is-active,.hero.is-black .nav-item a:not(.button):hover,.hero.is-black .tabs.is-boxed a,.hero.is-black .tabs.is-toggle a,.hero.is-black a.nav-item.is-active,.hero.is-black a.nav-item:hover{color:#fff}.hero.is-black .tabs a{color:#fff;opacity:.5}.hero.is-black .tabs a:hover,.hero.is-black .tabs li.is-active a{opacity:1}.hero.is-black .tabs.is-boxed a:hover,.hero.is-black .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-black .tabs.is-boxed li.is-active a,.hero.is-black .tabs.is-boxed li.is-active a:hover,.hero.is-black .tabs.is-toggle li.is-active a,.hero.is-black .tabs.is-toggle li.is-active a:hover{background-color:#fff;border-color:#fff;color:#111}.hero.is-black.is-bold{background-image:-webkit-linear-gradient(309deg,#000 0,#111 71%,#1f1c1c 100%);background-image:linear-gradient(141deg,#000 0,#111 71%,#1f1c1c 100%)}@media screen and (max-width:768px){.hero.is-black .nav-toggle span{background-color:#fff}.hero.is-black .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-black .nav-toggle.is-active span{background-color:#fff}.hero.is-black .nav-menu .nav-item{border-top-color:rgba(255,255,255,.2)}.hero.is-light .nav-menu{background-color:#f5f7fa}}.hero.is-light{background-color:#f5f7fa;color:#42464c}.hero.is-light .title{color:#42464c}.hero.is-light .title a,.hero.is-light .title strong{color:inherit}.hero.is-light .subtitle{color:rgba(66,70,76,.7)}.hero.is-light .subtitle a,.hero.is-light .subtitle strong{color:#42464c}.hero.is-light .nav{box-shadow:0 1px 0 rgba(66,70,76,.2)}.hero.is-light .nav-item a:not(.button),.hero.is-light a.nav-item{color:rgba(66,70,76,.5)}.hero.is-light .nav-item a:not(.button).is-active,.hero.is-light .nav-item a:not(.button):hover,.hero.is-light .tabs.is-boxed a,.hero.is-light .tabs.is-toggle a,.hero.is-light a.nav-item.is-active,.hero.is-light a.nav-item:hover{color:#42464c}.hero.is-light .tabs a{color:#42464c;opacity:.5}.hero.is-light .tabs a:hover,.hero.is-light .tabs li.is-active a{opacity:1}.hero.is-dark,.hero.is-dark .title{color:#f5f7fa}.hero.is-light .tabs.is-boxed a:hover,.hero.is-light .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-light .tabs.is-boxed li.is-active a,.hero.is-light .tabs.is-boxed li.is-active a:hover,.hero.is-light .tabs.is-toggle li.is-active a,.hero.is-light .tabs.is-toggle li.is-active a:hover{background-color:#42464c;border-color:#42464c;color:#f5f7fa}.hero.is-light.is-bold{background-image:-webkit-linear-gradient(309deg,#d0e0ec 0,#f5f7fa 71%,#fff 100%);background-image:linear-gradient(141deg,#d0e0ec 0,#f5f7fa 71%,#fff 100%)}@media screen and (max-width:768px){.hero.is-light .nav-toggle span{background-color:#42464c}.hero.is-light .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-dark .nav-menu,.hero.is-light .nav-toggle.is-active span{background-color:#42464c}.hero.is-light .nav-menu .nav-item{border-top-color:rgba(66,70,76,.2)}}.hero.is-dark{background-color:#42464c}.hero.is-dark .title a,.hero.is-dark .title strong{color:inherit}.hero.is-dark .subtitle{color:rgba(245,247,250,.7)}.hero.is-dark .subtitle a,.hero.is-dark .subtitle strong{color:#f5f7fa}.hero.is-dark .nav{box-shadow:0 1px 0 rgba(245,247,250,.2)}.hero.is-info .nav,.hero.is-primary .nav,.hero.is-success .nav{box-shadow:0 1px 0 rgba(255,255,255,.2)}.hero.is-dark .nav-item a:not(.button),.hero.is-dark a.nav-item{color:rgba(245,247,250,.5)}.hero.is-dark .nav-item a:not(.button).is-active,.hero.is-dark .nav-item a:not(.button):hover,.hero.is-dark .tabs.is-boxed a,.hero.is-dark .tabs.is-toggle a,.hero.is-dark a.nav-item.is-active,.hero.is-dark a.nav-item:hover{color:#f5f7fa}.hero.is-dark .tabs a{color:#f5f7fa;opacity:.5}.hero.is-dark .tabs a:hover,.hero.is-dark .tabs li.is-active a{opacity:1}.hero.is-dark .tabs.is-boxed a:hover,.hero.is-dark .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-dark .tabs.is-boxed li.is-active a,.hero.is-dark .tabs.is-boxed li.is-active a:hover,.hero.is-dark .tabs.is-toggle li.is-active a,.hero.is-dark .tabs.is-toggle li.is-active a:hover{background-color:#f5f7fa;border-color:#f5f7fa;color:#42464c}.hero.is-dark.is-bold{background-image:-webkit-linear-gradient(309deg,#262f35 0,#42464c 71%,#4a4e5e 100%);background-image:linear-gradient(141deg,#262f35 0,#42464c 71%,#4a4e5e 100%)}@media screen and (max-width:768px){.hero.is-dark .nav-toggle span{background-color:#f5f7fa}.hero.is-dark .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-dark .nav-toggle.is-active span{background-color:#f5f7fa}.hero.is-dark .nav-menu .nav-item{border-top-color:rgba(245,247,250,.2)}.hero.is-primary .nav-menu{background-color:#2077b2}}.hero.is-primary{background-color:#2077b2;color:#fff}.hero.is-primary .title{color:#fff}.hero.is-primary .title a,.hero.is-primary .title strong{color:inherit}.hero.is-primary .subtitle{color:rgba(255,255,255,.7)}.hero.is-primary .subtitle a,.hero.is-primary .subtitle strong{color:#fff}.hero.is-primary .nav-item a:not(.button),.hero.is-primary a.nav-item{color:rgba(255,255,255,.5)}.hero.is-primary .nav-item a:not(.button).is-active,.hero.is-primary .nav-item a:not(.button):hover,.hero.is-primary .tabs.is-boxed a,.hero.is-primary .tabs.is-toggle a,.hero.is-primary a.nav-item.is-active,.hero.is-primary a.nav-item:hover{color:#fff}.hero.is-primary .tabs a{color:#fff;opacity:.5}.hero.is-primary .tabs a:hover,.hero.is-primary .tabs li.is-active a{opacity:1}.hero.is-primary .tabs.is-boxed a:hover,.hero.is-primary .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-primary .tabs.is-boxed li.is-active a,.hero.is-primary .tabs.is-boxed li.is-active a:hover,.hero.is-primary .tabs.is-toggle li.is-active a,.hero.is-primary .tabs.is-toggle li.is-active a:hover{background-color:#fff;border-color:#fff;color:#2077b2}.hero.is-primary.is-bold{background-image:-webkit-linear-gradient(309deg,#10718f 0,#2077b2 71%,#1e69ce 100%);background-image:linear-gradient(141deg,#10718f 0,#2077b2 71%,#1e69ce 100%)}@media screen and (max-width:768px){.hero.is-primary .nav-toggle span{background-color:#fff}.hero.is-primary .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-primary .nav-toggle.is-active span{background-color:#fff}.hero.is-primary .nav-menu .nav-item{border-top-color:rgba(255,255,255,.2)}.hero.is-info .nav-menu{background-color:#2077b2}}.hero.is-info{background-color:#2077b2;color:#fff}.hero.is-info .title{color:#fff}.hero.is-info .title a,.hero.is-info .title strong{color:inherit}.hero.is-info .subtitle{color:rgba(255,255,255,.7)}.hero.is-info .subtitle a,.hero.is-info .subtitle strong{color:#fff}.hero.is-info .nav-item a:not(.button),.hero.is-info a.nav-item{color:rgba(255,255,255,.5)}.hero.is-info .nav-item a:not(.button).is-active,.hero.is-info .nav-item a:not(.button):hover,.hero.is-info .tabs.is-boxed a,.hero.is-info .tabs.is-toggle a,.hero.is-info a.nav-item.is-active,.hero.is-info a.nav-item:hover{color:#fff}.hero.is-info .tabs a{color:#fff;opacity:.5}.hero.is-info .tabs a:hover,.hero.is-info .tabs li.is-active a{opacity:1}.hero.is-info .tabs.is-boxed a:hover,.hero.is-info .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-info .tabs.is-boxed li.is-active a,.hero.is-info .tabs.is-boxed li.is-active a:hover,.hero.is-info .tabs.is-toggle li.is-active a,.hero.is-info .tabs.is-toggle li.is-active a:hover{background-color:#fff;border-color:#fff;color:#2077b2}.hero.is-info.is-bold{background-image:-webkit-linear-gradient(309deg,#10718f 0,#2077b2 71%,#1e69ce 100%);background-image:linear-gradient(141deg,#10718f 0,#2077b2 71%,#1e69ce 100%)}@media screen and (max-width:768px){.hero.is-info .nav-toggle span{background-color:#fff}.hero.is-info .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-info .nav-toggle.is-active span{background-color:#fff}.hero.is-info .nav-menu .nav-item{border-top-color:rgba(255,255,255,.2)}.hero.is-success .nav-menu{background-color:#97cd76}}.hero.is-success{background-color:#97cd76;color:#fff}.hero.is-success .title{color:#fff}.hero.is-success .title a,.hero.is-success .title strong{color:inherit}.hero.is-success .subtitle{color:rgba(255,255,255,.7)}.hero.is-success .subtitle a,.hero.is-success .subtitle strong{color:#fff}.hero.is-success .nav-item a:not(.button),.hero.is-success a.nav-item{color:rgba(255,255,255,.5)}.hero.is-success .nav-item a:not(.button).is-active,.hero.is-success .nav-item a:not(.button):hover,.hero.is-success .tabs.is-boxed a,.hero.is-success .tabs.is-toggle a,.hero.is-success a.nav-item.is-active,.hero.is-success a.nav-item:hover{color:#fff}.hero.is-success .tabs a{color:#fff;opacity:.5}.hero.is-success .tabs a:hover,.hero.is-success .tabs li.is-active a{opacity:1}.hero.is-success .tabs.is-boxed a:hover,.hero.is-success .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-success .tabs.is-boxed li.is-active a,.hero.is-success .tabs.is-boxed li.is-active a:hover,.hero.is-success .tabs.is-toggle li.is-active a,.hero.is-success .tabs.is-toggle li.is-active a:hover{background-color:#fff;border-color:#fff;color:#97cd76}.hero.is-warning,.hero.is-warning .title{color:rgba(17,17,17,.5)}.hero.is-success.is-bold{background-image:-webkit-linear-gradient(309deg,#8ecb45 0,#97cd76 71%,#96d885 100%);background-image:linear-gradient(141deg,#8ecb45 0,#97cd76 71%,#96d885 100%)}@media screen and (max-width:768px){.hero.is-success .nav-toggle span{background-color:#fff}.hero.is-success .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-success .nav-toggle.is-active span{background-color:#fff}.hero.is-success .nav-menu .nav-item{border-top-color:rgba(255,255,255,.2)}.hero.is-warning .nav-menu{background-color:#fce473}}.hero.is-warning{background-color:#fce473}.hero.is-warning .title a,.hero.is-warning .title strong{color:inherit}.hero.is-warning .subtitle{color:rgba(17,17,17,.7)}.hero.is-warning .nav-item a:not(.button),.hero.is-warning .nav-item a:not(.button).is-active,.hero.is-warning .nav-item a:not(.button):hover,.hero.is-warning .subtitle a,.hero.is-warning .subtitle strong,.hero.is-warning .tabs.is-boxed a,.hero.is-warning .tabs.is-toggle a,.hero.is-warning a.nav-item,.hero.is-warning a.nav-item.is-active,.hero.is-warning a.nav-item:hover{color:rgba(17,17,17,.5)}.hero.is-warning .nav{box-shadow:0 1px 0 rgba(17,17,17,.2)}.hero.is-warning .tabs a{color:rgba(17,17,17,.5);opacity:.5}.hero.is-warning .tabs a:hover,.hero.is-warning .tabs li.is-active a{opacity:1}.hero.is-warning .tabs.is-boxed a:hover,.hero.is-warning .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-warning .tabs.is-boxed li.is-active a,.hero.is-warning .tabs.is-boxed li.is-active a:hover,.hero.is-warning .tabs.is-toggle li.is-active a,.hero.is-warning .tabs.is-toggle li.is-active a:hover{background-color:rgba(17,17,17,.5);border-color:rgba(17,17,17,.5);color:#fce473}.hero.is-warning.is-bold{background-image:-webkit-linear-gradient(309deg,#ffbd3d 0,#fce473 71%,#fffe8a 100%);background-image:linear-gradient(141deg,#ffbd3d 0,#fce473 71%,#fffe8a 100%)}@media screen and (max-width:768px){.hero.is-warning .nav-toggle span{background-color:rgba(17,17,17,.5)}.hero.is-warning .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-warning .nav-toggle.is-active span{background-color:rgba(17,17,17,.5)}.hero.is-warning .nav-menu .nav-item{border-top-color:rgba(17,17,17,.2)}.hero.is-danger .nav-menu{background-color:#ed6c63}}.hero.is-danger{background-color:#ed6c63;color:#fff}.hero.is-danger .title{color:#fff}.hero.is-danger .title a,.hero.is-danger .title strong{color:inherit}.hero.is-danger .subtitle{color:rgba(255,255,255,.7)}.hero.is-danger .subtitle a,.hero.is-danger .subtitle strong{color:#fff}.hero.is-danger .nav{box-shadow:0 1px 0 rgba(255,255,255,.2)}.hero.is-danger .nav-item a:not(.button),.hero.is-danger a.nav-item{color:rgba(255,255,255,.5)}.hero.is-danger .nav-item a:not(.button).is-active,.hero.is-danger .nav-item a:not(.button):hover,.hero.is-danger .tabs.is-boxed a,.hero.is-danger .tabs.is-toggle a,.hero.is-danger a.nav-item.is-active,.hero.is-danger a.nav-item:hover{color:#fff}.hero.is-danger .tabs a{color:#fff;opacity:.5}.hero.is-danger .tabs a:hover,.hero.is-danger .tabs li.is-active a{opacity:1}.hero.is-danger .tabs.is-boxed a:hover,.hero.is-danger .tabs.is-toggle a:hover{background-color:rgba(17,17,17,.1)}.hero.is-danger .tabs.is-boxed li.is-active a,.hero.is-danger .tabs.is-boxed li.is-active a:hover,.hero.is-danger .tabs.is-toggle li.is-active a,.hero.is-danger .tabs.is-toggle li.is-active a:hover{background-color:#fff;border-color:#fff;color:#ed6c63}.hero.is-danger.is-bold{background-image:-webkit-linear-gradient(309deg,#f32a3e 0,#ed6c63 71%,#f39376 100%);background-image:linear-gradient(141deg,#f32a3e 0,#ed6c63 71%,#f39376 100%)}@media screen and (max-width:768px){.hero.is-danger .nav-toggle span{background-color:#fff}.hero.is-danger .nav-toggle:hover{background-color:rgba(17,17,17,.1)}.hero.is-danger .nav-toggle.is-active span{background-color:#fff}.hero.is-danger .nav-menu .nav-item{border-top-color:rgba(255,255,255,.2)}}@media screen and (min-width:769px){.hero.is-medium .hero-body{padding-bottom:120px;padding-top:120px}.hero.is-large .hero-body{padding-bottom:240px;padding-top:240px}}.hero.is-fullheight{min-height:100vh}.hero.is-fullheight .hero-body{-webkit-box-align:center;-ms-flex-align:center;align-items:center;display:-webkit-box;display:-ms-flexbox;display:flex}.hero.is-fullheight .hero-body>.container{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1}.section{background-color:#fff;padding:40px 20px}@media screen and (min-width:980px){.section.is-medium{padding:120px 20px}.section.is-large{padding:240px 20px}}.footer{background-color:#f5f7fa;padding:40px 20px 80px}code,html{background-color:transparent}.footer a,.footer a:visited{color:#42464c}.footer a:hover,.footer a:visited:hover{color:#222324}.footer a:not(.icon),.footer a:visited:not(.icon){border-bottom:1px solid #d3d6db}.footer a:not(.icon):hover,.footer a:visited:not(.icon):hover{border-bottom-color:#2077b2}.container{max-width:800px;margin:0 auto}.content h1:not(:first-child),.content h2:not(:first-child),.content h3:not(:first-child),.content h4:not(:first-child),.content h5:not(:first-child),.content h6:not(:first-child),article+article{margin-top:80px}.content{font-size:16px;line-height:1.75}.media-content .subtitle+.title{margin-bottom:10px}.media-content .content{line-height:1.5}.content h1,.content h2,.content h3,.content h4,.content h5,.content h6,.title{line-height:1.25}.hero .nav{box-shadow:none}.nav .level-item{margin-left:10px}.subtitle{color:#69707a}.title{font-size:24px}.title a{color:#222324}.title.notfound{font-size:20vw}code{color:inherit;font-size:90%}.content h1::before,.content h2::before,.content h3::before,.content h4::before,.content h5::before,.content h6::before{color:#aeb1b5;font-weight:700}.content h1 code,.content h2 code,.content h3 code,.content h4 code,.content h5 code,.content h6 code{background-color:#8a2be2}.content h1+h2:not(:first-child),.content h2+h3:not(:first-child),.content h3+h4:not(:first-child),.content h4+h5:not(:first-child),.content h5+h6:not(:first-child){margin-top:20px}.content h1{font-size:24px}.content h2{font-size:22px}.content h3{font-size:20px}.content h4{font-size:18px}.content h5{font-size:17px}.content h6{font-size:16px}.content ol:not(:last-child),.content p:not(:last-child),.content pre:not(:last-child),.content table:not(:last-child),.content ul:not(:last-child){margin-bottom:1.5em}.content table td,.content table th{border:1px solid #d3d6db;padding:8px 10px;vertical-align:top}.content p>code,.content>code{font-size:90%;padding:2px 4px;margin:0 2px;border:1px solid #ddd;border-radius:4px;background-color:#f8f8f8;color:#42464c}.content pre code{font-size:90%;padding:1em;line-height:1.5}.content li pre,.content li table{margin-bottom:1.5em}img[src$='#c']{display:block;margin:.7rem auto}img[src$='#l']{float:left;margin:.7rem}img[src$='#r']{float:right;margin:.7rem}.related a:not(.button){border-bottom:none}.related a:not(.button):visited{color:#000}.related ul{font-size:17px}
+﻿.card,
+.highlight,
+.highlight pre,
+.textarea,
+embed,
+img,
+object {
+  max-width: 100%;
+}
+a,
+hr {
+  padding: 0;
+}
+a,
+button,
+input[type="button"],
+input[type="file"],
+input[type="submit"],
+label {
+  cursor: pointer;
+}
+a,
+button,
+input,
+select,
+textarea {
+  margin: 0;
+}
+a,
+input[type="checkbox"],
+input[type="radio"] {
+  vertical-align: baseline;
+}
+a:hover,
+strong,
+table th {
+  color: #222324;
+}
+.container,
+sub,
+sup {
+  position: relative;
+}
+.is-block,
+article,
+aside,
+details,
+figure,
+footer,
+header,
+hgroup,
+hr,
+nav,
+pre code,
+section,
+summary {
+  display: block;
+}
+.button,
+.delete,
+.input,
+.modal-close,
+.progress,
+.select select,
+.textarea {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+}
+.heading,
+.menu-label {
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.hero,
+.modal-card,
+.tile.is-vertical {
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+}
+abbr,
+address,
+article,
+aside,
+audio,
+b,
+blockquote,
+body,
+body div,
+caption,
+cite,
+code,
+dd,
+del,
+details,
+dfn,
+dl,
+dt,
+em,
+fieldset,
+figure,
+footer,
+form,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+header,
+html,
+i,
+iframe,
+img,
+ins,
+kbd,
+label,
+legend,
+li,
+mark,
+menu,
+nav,
+object,
+ol,
+p,
+pre,
+q,
+samp,
+section,
+small,
+span,
+strong,
+sub,
+summary,
+sup,
+table,
+tbody,
+td,
+tfoot,
+th,
+thead,
+time,
+tr,
+ul,
+var,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font-weight: 400;
+  vertical-align: baseline;
+  background: 0 0;
+}
+td,
+td img {
+  vertical-align: top;
+}
+pre,
+pre code {
+  background-color: #f5f7fa;
+  color: #42464c;
+}
+*,
+:after,
+:before {
+  box-sizing: inherit;
+}
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:after,
+blockquote:before,
+q:after,
+q:before {
+  content: "";
+  content: none;
+}
+.is-clearfix:after,
+.notification:after,
+.select:after {
+  content: " ";
+}
+a {
+  font-size: 100%;
+  background: 0 0;
+  color: #2077b2;
+  text-decoration: none;
+  -webkit-transition: none 86ms ease-out;
+  transition: none 86ms ease-out;
+}
+del {
+  text-decoration: line-through;
+}
+abbr[title],
+dfn[title] {
+  border-bottom: 1px dotted #000;
+  cursor: help;
+}
+th {
+  font-weight: 700;
+  vertical-align: bottom;
+}
+body,
+code,
+td {
+  font-weight: 400;
+}
+hr {
+  height: 1px;
+  border: 0;
+  border-top: 1px solid #ccc;
+  border-top-color: #d3d6db;
+  margin: 40px 0;
+}
+input,
+select {
+  vertical-align: middle;
+}
+input,
+select,
+textarea {
+  font: 99% sans-serif;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  font: 100%;
+  width: 100%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+}
+sup {
+  top: -0.5em;
+}
+sub {
+  bottom: -0.25em;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, sans-serif;
+}
+button,
+input[type="button"] {
+  width: auto;
+  overflow: visible;
+}
+@-webkit-keyframes spin-around {
+  from {
+    -webkit-transform: rotate(0);
+    transform: rotate(0);
+  }
+  to {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+@keyframes spin-around {
+  from {
+    -webkit-transform: rotate(0);
+    transform: rotate(0);
+  }
+  to {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+html {
+  box-sizing: border-box;
+  font-size: 14px;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  min-width: 300px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  text-rendering: optimizeLegibility;
+}
+body,
+button,
+input,
+select,
+textarea {
+  font-family: "游ゴシック", YuGothic, "ヒラギノ角ゴ Pro",
+    "Hiragino Kaku Gothic Pro", "メイリオ", Meiryo, sans-serif;
+}
+code,
+pre {
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: auto;
+  font-family: "Source Code Pro", Monaco, Inconsolata, monospace;
+  line-height: 1.25;
+}
+body {
+  color: #42464c;
+  font-size: 1rem;
+  line-height: 1.428571428571429;
+}
+code {
+  padding: 1px 2px 2px;
+}
+.button,
+.input,
+.textarea,
+table td,
+table th {
+  vertical-align: top;
+}
+small {
+  font-size: 11px;
+}
+span {
+  font-style: inherit;
+  font-weight: inherit;
+}
+.label,
+strong {
+  font-weight: 700;
+}
+pre {
+  white-space: pre;
+  word-wrap: normal;
+}
+.button,
+.nav-left,
+.table td.is-icon,
+.table th.is-icon,
+.tabs,
+.tag {
+  white-space: nowrap;
+}
+pre code {
+  overflow-x: auto;
+  padding: 16px 20px;
+}
+.box,
+.button {
+  background-color: #fff;
+}
+table td,
+table th {
+  text-align: left;
+}
+.has-text-centered {
+  text-align: center;
+}
+.block:not(:last-child),
+.box:not(:last-child),
+.content:not(:last-child),
+.highlight:not(:last-child),
+.level:not(:last-child),
+.message:not(:last-child),
+.notification:not(:last-child),
+.progress:not(:last-child),
+.subtitle:not(:last-child),
+.tabs:not(:last-child),
+.title:not(:last-child) {
+  margin-bottom: 20px;
+}
+@media screen and (min-width: 980px) {
+  .container {
+    margin: 0 auto;
+    max-width: 960px;
+  }
+  .container.is-fluid {
+    margin: 0 20px;
+    max-width: none;
+  }
+  .is-block-desktop {
+    display: block !important;
+  }
+}
+@media screen and (max-width: 768px) {
+  .is-block-mobile {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 769px) {
+  .is-block-tablet {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 979px) {
+  .is-block-tablet-only {
+    display: block !important;
+  }
+}
+@media screen and (max-width: 979px) {
+  .is-block-touch {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 980px) and (max-width: 1179px) {
+  .is-block-desktop-only {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 1180px) {
+  .container {
+    max-width: 1200px;
+  }
+  .is-block-widescreen {
+    display: block !important;
+  }
+}
+.is-flex {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+@media screen and (max-width: 768px) {
+  .is-flex-mobile {
+    display: -webkit-box !important;
+    display: -ms-flexbox !important;
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 769px) {
+  .is-flex-tablet {
+    display: -webkit-box !important;
+    display: -ms-flexbox !important;
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 979px) {
+  .is-flex-tablet-only {
+    display: -webkit-box !important;
+    display: -ms-flexbox !important;
+    display: flex !important;
+  }
+}
+@media screen and (max-width: 979px) {
+  .is-flex-touch {
+    display: -webkit-box !important;
+    display: -ms-flexbox !important;
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 980px) {
+  .is-flex-desktop {
+    display: -webkit-box !important;
+    display: -ms-flexbox !important;
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 980px) and (max-width: 1179px) {
+  .is-flex-desktop-only {
+    display: -webkit-box !important;
+    display: -ms-flexbox !important;
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 1180px) {
+  .is-flex-widescreen {
+    display: -webkit-box !important;
+    display: -ms-flexbox !important;
+    display: flex !important;
+  }
+}
+.is-inline {
+  display: inline;
+}
+@media screen and (max-width: 768px) {
+  .is-inline-mobile {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 769px) {
+  .is-inline-tablet {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 979px) {
+  .is-inline-tablet-only {
+    display: inline !important;
+  }
+}
+@media screen and (max-width: 979px) {
+  .is-inline-touch {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 980px) {
+  .is-inline-desktop {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 980px) and (max-width: 1179px) {
+  .is-inline-desktop-only {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 1180px) {
+  .is-inline-widescreen {
+    display: inline !important;
+  }
+}
+.is-inline-block {
+  display: inline-block;
+}
+@media screen and (max-width: 768px) {
+  .is-inline-block-mobile {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 769px) {
+  .is-inline-block-tablet {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 979px) {
+  .is-inline-block-tablet-only {
+    display: inline-block !important;
+  }
+}
+@media screen and (max-width: 979px) {
+  .is-inline-block-touch {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 980px) {
+  .is-inline-block-desktop {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 980px) and (max-width: 1179px) {
+  .is-inline-block-desktop-only {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 1180px) {
+  .is-inline-block-widescreen {
+    display: inline-block !important;
+  }
+}
+.is-inline-flex {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+@media screen and (max-width: 768px) {
+  .is-inline-flex-mobile {
+    display: -webkit-inline-box !important;
+    display: -ms-inline-flexbox !important;
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 769px) {
+  .is-inline-flex-tablet {
+    display: -webkit-inline-box !important;
+    display: -ms-inline-flexbox !important;
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 979px) {
+  .is-inline-flex-tablet-only {
+    display: -webkit-inline-box !important;
+    display: -ms-inline-flexbox !important;
+    display: inline-flex !important;
+  }
+}
+@media screen and (max-width: 979px) {
+  .is-inline-flex-touch {
+    display: -webkit-inline-box !important;
+    display: -ms-inline-flexbox !important;
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 980px) {
+  .is-inline-flex-desktop {
+    display: -webkit-inline-box !important;
+    display: -ms-inline-flexbox !important;
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 980px) and (max-width: 1179px) {
+  .is-inline-flex-desktop-only {
+    display: -webkit-inline-box !important;
+    display: -ms-inline-flexbox !important;
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 1180px) {
+  .is-inline-flex-widescreen {
+    display: -webkit-inline-box !important;
+    display: -ms-inline-flexbox !important;
+    display: inline-flex !important;
+  }
+}
+.is-clearfix:after {
+  clear: both;
+  display: table;
+}
+.is-pulled-left {
+  float: left;
+}
+.is-pulled-right {
+  float: right;
+}
+.is-clipped {
+  overflow: hidden !important;
+}
+.is-overlay {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.has-text-left {
+  text-align: left;
+}
+.has-text-right {
+  text-align: right;
+}
+.is-hidden {
+  display: none !important;
+}
+@media screen and (max-width: 768px) {
+  .is-hidden-mobile {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 769px) {
+  .is-hidden-tablet {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 979px) {
+  .is-hidden-tablet-only {
+    display: none !important;
+  }
+}
+@media screen and (max-width: 979px) {
+  .is-hidden-touch {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 980px) {
+  .is-hidden-desktop {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 980px) and (max-width: 1179px) {
+  .is-hidden-desktop-only {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 1180px) {
+  .is-hidden-widescreen {
+    display: none !important;
+  }
+}
+.is-disabled {
+  pointer-events: none;
+}
+.is-marginless {
+  margin: 0 !important;
+}
+.box {
+  border-radius: 5px;
+  box-shadow: 0 2px 3px rgba(17, 17, 17, 0.1), 0 0 0 1px rgba(17, 17, 17, 0.1);
+  display: block;
+  padding: 20px;
+}
+a.box:focus,
+a.box:hover {
+  box-shadow: 0 2px 3px rgba(17, 17, 17, 0.1), 0 0 0 1px #2077b2;
+}
+a.box:active {
+  box-shadow: inset 0 1px 2px rgba(17, 17, 17, 0.2), 0 0 0 1px #2077b2;
+}
+.button {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #d3d6db;
+  border-radius: 3px;
+  color: #222324;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 14px;
+  height: 32px;
+  line-height: 24px;
+  position: relative;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 10px;
+  padding-right: 10px;
+  text-align: center;
+}
+.button:hover {
+  border-color: #aeb1b5;
+}
+.button.is-active,
+.button:active,
+.button:focus {
+  border-color: #2077b2;
+  outline: 0;
+}
+.button.is-disabled,
+.button[disabled] {
+  background-color: #f5f7fa;
+  border-color: #d3d6db;
+  cursor: not-allowed;
+  pointer-events: none;
+  opacity: 0.5;
+}
+.button.is-white,
+.button.is-white:active {
+  border-color: transparent;
+}
+.button.is-disabled::-moz-placeholder,
+.button[disabled]::-moz-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.button.is-disabled::-webkit-input-placeholder,
+.button[disabled]::-webkit-input-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.button.is-disabled:-moz-placeholder,
+.button[disabled]:-moz-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.button.is-disabled:-ms-input-placeholder,
+.button[disabled]:-ms-input-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.button strong {
+  color: inherit;
+}
+.button small {
+  display: block;
+  font-size: 11px;
+  line-height: 1;
+  margin-top: 5px;
+}
+.button .icon:first-child,
+.button .tag:first-child {
+  margin-left: -2px;
+  margin-right: 4px;
+}
+.button .icon:last-child,
+.button .tag:last-child {
+  margin-left: 4px;
+  margin-right: -2px;
+}
+.button.is-active,
+.button:focus,
+.button:hover {
+  color: #222324;
+}
+.button:active {
+  box-shadow: inset 0 1px 2px rgba(17, 17, 17, 0.2);
+}
+.button.is-white {
+  background-color: #fff;
+  color: #111;
+}
+.button.is-white.is-active,
+.button.is-white:focus,
+.button.is-white:hover {
+  background-color: #e6e6e6;
+  border-color: transparent;
+  color: #111;
+}
+.button.is-white.is-inverted {
+  background-color: #111;
+  color: #fff;
+}
+.button.is-white.is-inverted:hover {
+  background-color: #040404;
+}
+.button.is-white.is-loading:after {
+  border-color: transparent transparent #111 #111 !important;
+}
+.button.is-white.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.button.is-white.is-outlined:focus,
+.button.is-white.is-outlined:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #111;
+}
+.button.is-black,
+.button.is-black:active {
+  border-color: transparent;
+}
+.button.is-black {
+  background-color: #111;
+  color: #fff;
+}
+.button.is-black.is-active,
+.button.is-black:focus,
+.button.is-black:hover {
+  background-color: #000;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-black.is-inverted {
+  background-color: #fff;
+  color: #111;
+}
+.button.is-black.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+.button.is-black.is-loading:after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-black.is-outlined {
+  background-color: transparent;
+  border-color: #111;
+  color: #111;
+}
+.button.is-black.is-outlined:focus,
+.button.is-black.is-outlined:hover {
+  background-color: #111;
+  border-color: #111;
+  color: #fff;
+}
+.button.is-light,
+.button.is-light:active {
+  border-color: transparent;
+}
+.button.is-light {
+  background-color: #f5f7fa;
+  color: #42464c;
+}
+.button.is-light.is-active,
+.button.is-light:focus,
+.button.is-light:hover {
+  background-color: #d3dce9;
+  border-color: transparent;
+  color: #42464c;
+}
+.button.is-light.is-inverted {
+  background-color: #42464c;
+  color: #f5f7fa;
+}
+.button.is-light.is-inverted:hover {
+  background-color: #36393e;
+}
+.button.is-light.is-loading:after {
+  border-color: transparent transparent #42464c #42464c !important;
+}
+.button.is-light.is-outlined {
+  background-color: transparent;
+  border-color: #f5f7fa;
+  color: #f5f7fa;
+}
+.button.is-light.is-outlined:focus,
+.button.is-light.is-outlined:hover {
+  background-color: #f5f7fa;
+  border-color: #f5f7fa;
+  color: #42464c;
+}
+.button.is-dark,
+.button.is-dark:active {
+  border-color: transparent;
+}
+.button.is-dark {
+  background-color: #42464c;
+  color: #f5f7fa;
+}
+.button.is-dark.is-active,
+.button.is-dark:focus,
+.button.is-dark:hover {
+  background-color: #2a2d31;
+  border-color: transparent;
+  color: #f5f7fa;
+}
+.button.is-dark.is-inverted {
+  background-color: #f5f7fa;
+  color: #42464c;
+}
+.button.is-dark.is-inverted:hover {
+  background-color: #e4e9f2;
+}
+.button.is-dark.is-loading:after {
+  border-color: transparent transparent #f5f7fa #f5f7fa !important;
+}
+.button.is-dark.is-outlined {
+  background-color: transparent;
+  border-color: #42464c;
+  color: #42464c;
+}
+.button.is-dark.is-outlined:focus,
+.button.is-dark.is-outlined:hover {
+  background-color: #42464c;
+  border-color: #42464c;
+  color: #f5f7fa;
+}
+.button.is-primary,
+.button.is-primary:active {
+  border-color: transparent;
+}
+.button.is-primary {
+  background-color: #2077b2;
+  color: #fff;
+}
+.button.is-primary.is-active,
+.button.is-primary:focus,
+.button.is-primary:hover {
+  background-color: #185a87;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-primary.is-inverted {
+  background-color: #fff;
+  color: #2077b2;
+}
+.button.is-primary.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+.button.is-primary.is-loading:after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-primary.is-outlined {
+  background-color: transparent;
+  border-color: #2077b2;
+  color: #2077b2;
+}
+.button.is-primary.is-outlined:focus,
+.button.is-primary.is-outlined:hover {
+  background-color: #2077b2;
+  border-color: #2077b2;
+  color: #fff;
+}
+.button.is-info,
+.button.is-info:active {
+  border-color: transparent;
+}
+.button.is-info {
+  background-color: #2077b2;
+  color: #fff;
+}
+.button.is-info.is-active,
+.button.is-info:focus,
+.button.is-info:hover {
+  background-color: #185a87;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-info.is-inverted {
+  background-color: #fff;
+  color: #2077b2;
+}
+.button.is-info.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+.button.is-info.is-loading:after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-info.is-outlined {
+  background-color: transparent;
+  border-color: #2077b2;
+  color: #2077b2;
+}
+.button.is-info.is-outlined:focus,
+.button.is-info.is-outlined:hover {
+  background-color: #2077b2;
+  border-color: #2077b2;
+  color: #fff;
+}
+.button.is-success,
+.button.is-success:active {
+  border-color: transparent;
+}
+.button.is-success {
+  background-color: #97cd76;
+  color: #fff;
+}
+.button.is-success.is-active,
+.button.is-success:focus,
+.button.is-success:hover {
+  background-color: #7bbf51;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-success.is-inverted {
+  background-color: #fff;
+  color: #97cd76;
+}
+.button.is-success.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+.button.is-success.is-loading:after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-success.is-outlined {
+  background-color: transparent;
+  border-color: #97cd76;
+  color: #97cd76;
+}
+.button.is-success.is-outlined:focus,
+.button.is-success.is-outlined:hover {
+  background-color: #97cd76;
+  border-color: #97cd76;
+  color: #fff;
+}
+.button.is-warning,
+.button.is-warning:active {
+  border-color: transparent;
+}
+.button.is-warning {
+  background-color: #fce473;
+  color: rgba(17, 17, 17, 0.5);
+}
+.button.is-warning.is-active,
+.button.is-warning:focus,
+.button.is-warning:hover {
+  background-color: #fbda41;
+  border-color: transparent;
+  color: rgba(17, 17, 17, 0.5);
+}
+.button.is-warning.is-inverted {
+  background-color: rgba(17, 17, 17, 0.5);
+  color: #fce473;
+}
+.button.is-warning.is-inverted:hover {
+  background-color: rgba(4, 4, 4, 0.5);
+}
+.button.is-warning.is-loading:after {
+  border-color: transparent transparent rgba(17, 17, 17, 0.5)
+    rgba(17, 17, 17, 0.5) !important;
+}
+.button.is-warning.is-outlined {
+  background-color: transparent;
+  border-color: #fce473;
+  color: #fce473;
+}
+.button.is-warning.is-outlined:focus,
+.button.is-warning.is-outlined:hover {
+  background-color: #fce473;
+  border-color: #fce473;
+  color: rgba(17, 17, 17, 0.5);
+}
+.button.is-danger,
+.button.is-danger:active {
+  border-color: transparent;
+}
+.button.is-danger {
+  background-color: #ed6c63;
+  color: #fff;
+}
+.button.is-danger.is-active,
+.button.is-danger:focus,
+.button.is-danger:hover {
+  background-color: #e84135;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-danger.is-inverted {
+  background-color: #fff;
+  color: #ed6c63;
+}
+.button.is-danger.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+.button.is-danger.is-loading:after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-danger.is-outlined {
+  background-color: transparent;
+  border-color: #ed6c63;
+  color: #ed6c63;
+}
+.button.is-danger.is-outlined:focus,
+.button.is-danger.is-outlined:hover {
+  background-color: #ed6c63;
+  border-color: #ed6c63;
+  color: #fff;
+}
+.button.is-link {
+  background-color: transparent;
+  border-color: transparent;
+  color: #42464c;
+  text-decoration: underline;
+}
+.button.is-link:focus,
+.button.is-link:hover {
+  background-color: #d3d6db;
+  color: #222324;
+}
+.button.is-small {
+  border-radius: 2px;
+  font-size: 11px;
+  height: 24px;
+  line-height: 16px;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+.button.is-medium {
+  font-size: 18px;
+  height: 40px;
+  padding-left: 14px;
+  padding-right: 14px;
+}
+.button.is-large {
+  font-size: 22px;
+  height: 48px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+.button.is-fullwidth {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+.button.is-loading {
+  color: transparent !important;
+  pointer-events: none;
+}
+.button.is-loading:after {
+  left: 50%;
+  margin-left: -8px;
+  margin-top: -8px;
+  top: 50%;
+  position: absolute !important;
+}
+.content a:not(.button) {
+  border-bottom: 1px solid #d3d6db;
+}
+.content a:not(.button):visited {
+  color: #847bb9;
+}
+.content a:not(.button):hover {
+  border-bottom-color: #2077b2;
+}
+.content li + li {
+  margin-top: 0.25em;
+}
+.content ol,
+.content ul {
+  margin-left: 2em;
+  margin-right: 2em;
+  margin-top: 1em;
+}
+.content blockquote:not(:last-child),
+.content ol:not(:last-child),
+.content p:not(:last-child),
+.content ul:not(:last-child) {
+  margin-bottom: 1em;
+}
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
+  color: #b52323;
+  font-weight: 300;
+  margin-bottom: 20px;
+}
+.content blockquote {
+  background-color: #f5f7fa;
+  border-left: 5px solid #d3d6db;
+  padding: 1.5em;
+}
+.content ol {
+  list-style: decimal;
+}
+.content ul {
+  list-style: disc;
+}
+.content ul ul {
+  list-style-type: circle;
+  margin-top: 0.5em;
+}
+.content ul ul ul,
+.related ul {
+  list-style-type: square;
+}
+.content.is-medium {
+  font-size: 18px;
+}
+.content.is-medium code {
+  font-size: 14px;
+}
+.content.is-large {
+  font-size: 24px;
+}
+.content.is-large code {
+  font-size: 18px;
+}
+.input,
+.textarea {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #d3d6db;
+  border-radius: 3px;
+  color: #222324;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 14px;
+  height: 32px;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  line-height: 24px;
+  padding-left: 8px;
+  padding-right: 8px;
+  position: relative;
+  box-shadow: inset 0 1px 2px rgba(17, 17, 17, 0.1);
+  max-width: 100%;
+  width: 100%;
+}
+.input:hover,
+.textarea:hover {
+  border-color: #aeb1b5;
+}
+.input.is-active,
+.input:active,
+.input:focus,
+.is-active.textarea,
+.textarea:active,
+.textarea:focus {
+  border-color: #2077b2;
+  outline: 0;
+}
+.input.is-disabled,
+.input[disabled],
+.is-disabled.textarea,
+[disabled].textarea {
+  background-color: #f5f7fa;
+  border-color: #d3d6db;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.checkbox input,
+.radio input,
+.select select {
+  cursor: pointer;
+}
+.input.is-disabled::-moz-placeholder,
+.input[disabled]::-moz-placeholder,
+.is-disabled.textarea::-moz-placeholder,
+[disabled].textarea::-moz-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.input.is-disabled::-webkit-input-placeholder,
+.input[disabled]::-webkit-input-placeholder,
+.is-disabled.textarea::-webkit-input-placeholder,
+[disabled].textarea::-webkit-input-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.input.is-disabled:-moz-placeholder,
+.input[disabled]:-moz-placeholder,
+.is-disabled.textarea:-moz-placeholder,
+[disabled].textarea:-moz-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.input.is-disabled:-ms-input-placeholder,
+.input[disabled]:-ms-input-placeholder,
+.is-disabled.textarea:-ms-input-placeholder,
+[disabled].textarea:-ms-input-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.input.is-white,
+.is-white.textarea {
+  border-color: #fff;
+}
+.input.is-black,
+.is-black.textarea {
+  border-color: #111;
+}
+.input.is-light,
+.is-light.textarea {
+  border-color: #f5f7fa;
+}
+.input.is-dark,
+.is-dark.textarea {
+  border-color: #42464c;
+}
+.input.is-info,
+.input.is-primary,
+.is-info.textarea,
+.is-primary.textarea {
+  border-color: #2077b2;
+}
+.input.is-success,
+.is-success.textarea {
+  border-color: #97cd76;
+}
+.input.is-warning,
+.is-warning.textarea {
+  border-color: #fce473;
+}
+.input.is-danger,
+.is-danger.textarea {
+  border-color: #ed6c63;
+}
+.input[type="search"],
+[type="search"].textarea {
+  border-radius: 290486px;
+}
+.input.is-small,
+.is-small.textarea {
+  border-radius: 2px;
+  font-size: 11px;
+  height: 24px;
+  line-height: 16px;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+.input.is-medium,
+.is-medium.textarea {
+  font-size: 18px;
+  height: 40px;
+  line-height: 32px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+.input.is-large,
+.is-large.textarea {
+  font-size: 24px;
+  height: 48px;
+  line-height: 40px;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.input.is-fullwidth,
+.is-fullwidth.textarea {
+  display: block;
+  width: 100%;
+}
+.input.is-inline,
+.is-inline.textarea {
+  display: inline;
+}
+.textarea {
+  display: block;
+  line-height: 1.2;
+  max-height: 600px;
+  min-height: 120px;
+  min-width: 100%;
+  padding: 10px;
+  resize: vertical;
+}
+.checkbox,
+.radio,
+.select {
+  display: inline-block;
+  position: relative;
+  vertical-align: top;
+}
+.checkbox,
+.radio {
+  cursor: pointer;
+  line-height: 16px;
+}
+.checkbox:hover,
+.radio:hover {
+  color: #222324;
+}
+.is-disabled.checkbox,
+.is-disabled.radio {
+  color: #aeb1b5;
+  pointer-events: none;
+}
+.is-disabled.checkbox input,
+.is-disabled.radio input {
+  pointer-events: none;
+}
+.radio + .radio {
+  margin-left: 10px;
+}
+.select {
+  height: 32px;
+}
+.select select {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #d3d6db;
+  border-radius: 3px;
+  color: #222324;
+  font-size: 14px;
+  height: 32px;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  line-height: 24px;
+  padding-left: 8px;
+  position: relative;
+  display: block;
+  outline: 0;
+  padding-right: 36px;
+}
+.select select.is-active,
+.select select:active,
+.select select:focus {
+  border-color: #2077b2;
+  outline: 0;
+}
+.select select.is-disabled,
+.select select[disabled] {
+  background-color: #f5f7fa;
+  border-color: #d3d6db;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.select select.is-disabled::-moz-placeholder,
+.select select[disabled]::-moz-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.select select.is-disabled::-webkit-input-placeholder,
+.select select[disabled]::-webkit-input-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.select select.is-disabled:-moz-placeholder,
+.select select[disabled]:-moz-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.select select.is-disabled:-ms-input-placeholder,
+.select select[disabled]:-ms-input-placeholder {
+  color: rgba(34, 35, 36, 0.3);
+}
+.select select.is-white {
+  border-color: #fff;
+}
+.select select.is-black {
+  border-color: #111;
+}
+.select select.is-light {
+  border-color: #f5f7fa;
+}
+.select select.is-dark {
+  border-color: #42464c;
+}
+.select select.is-info,
+.select select.is-primary {
+  border-color: #2077b2;
+}
+.select select.is-success {
+  border-color: #97cd76;
+}
+.select select.is-warning {
+  border-color: #fce473;
+}
+.select select.is-danger {
+  border-color: #ed6c63;
+}
+.select select:hover {
+  border-color: #aeb1b5;
+}
+.select select::ms-expand {
+  display: none;
+}
+.help,
+.label,
+.select:after {
+  display: block;
+}
+.select.is-fullwidth,
+.select.is-fullwidth select {
+  width: 100%;
+}
+.select:after {
+  border: 1px solid #2077b2;
+  border-right: 0;
+  border-top: 0;
+  height: 7px;
+  pointer-events: none;
+  position: absolute;
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+  width: 7px;
+  margin-top: -6px;
+  right: 16px;
+  top: 50%;
+}
+.select:hover:after {
+  border-color: #222324;
+}
+.select.is-small {
+  height: 24px;
+}
+.select.is-small select {
+  border-radius: 2px;
+  font-size: 11px;
+  height: 24px;
+  line-height: 16px;
+  padding-left: 6px;
+  padding-right: 28px;
+}
+.select.is-medium {
+  height: 40px;
+}
+.select.is-medium select {
+  font-size: 18px;
+  height: 40px;
+  line-height: 32px;
+  padding-left: 10px;
+  padding-right: 44px;
+}
+.select.is-large {
+  height: 48px;
+}
+.select.is-large select {
+  font-size: 24px;
+  height: 48px;
+  line-height: 40px;
+  padding-left: 12px;
+  padding-right: 52px;
+}
+.label {
+  color: #222324;
+}
+.label:not(:last-child) {
+  margin-bottom: 5px;
+}
+.help {
+  font-size: 11px;
+  margin-top: 5px;
+}
+.help.is-white {
+  color: #fff;
+}
+.help.is-black {
+  color: #111;
+}
+.help.is-light {
+  color: #f5f7fa;
+}
+.help.is-dark {
+  color: #42464c;
+}
+.help.is-info,
+.help.is-primary {
+  color: #2077b2;
+}
+.help.is-success {
+  color: #97cd76;
+}
+.help.is-warning {
+  color: #fce473;
+}
+.help.is-danger {
+  color: #ed6c63;
+}
+@media screen and (max-width: 768px) {
+  .control-label {
+    margin-bottom: 5px;
+  }
+}
+@media screen and (min-width: 769px) {
+  .control-label {
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    margin-right: 20px;
+    padding-top: 7px;
+    text-align: right;
+  }
+}
+.control {
+  position: relative;
+  text-align: left;
+}
+.control:not(:last-child) {
+  margin-bottom: 10px;
+}
+.control.has-addons {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+.control.has-addons .button,
+.control.has-addons .input,
+.control.has-addons .select,
+.control.has-addons .textarea {
+  border-radius: 0;
+  margin-right: -1px;
+  width: auto;
+}
+.control.has-addons .button:hover,
+.control.has-addons .input:hover,
+.control.has-addons .select:hover,
+.control.has-addons .textarea:hover {
+  z-index: 2;
+}
+.control.has-addons .button:active,
+.control.has-addons .button:focus,
+.control.has-addons .input:active,
+.control.has-addons .input:focus,
+.control.has-addons .select:active,
+.control.has-addons .select:focus,
+.control.has-addons .textarea:active,
+.control.has-addons .textarea:focus {
+  z-index: 3;
+}
+.control.has-addons .button:first-child,
+.control.has-addons .button:first-child select,
+.control.has-addons .input:first-child,
+.control.has-addons .input:first-child select,
+.control.has-addons .select:first-child,
+.control.has-addons .select:first-child select,
+.control.has-addons .textarea:first-child,
+.control.has-addons .textarea:first-child select {
+  border-radius: 3px 0 0 3px;
+}
+.control.has-addons .button:last-child,
+.control.has-addons .button:last-child select,
+.control.has-addons .input:last-child,
+.control.has-addons .input:last-child select,
+.control.has-addons .select:last-child,
+.control.has-addons .select:last-child select,
+.control.has-addons .textarea:last-child,
+.control.has-addons .textarea:last-child select {
+  border-radius: 0 3px 3px 0;
+}
+.control.has-addons .button.is-expanded,
+.control.has-addons .input.is-expanded,
+.control.has-addons .is-expanded.textarea,
+.control.has-addons .select.is-expanded {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+.control.has-addons.has-addons-centered {
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+.control.has-addons.has-addons-right {
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+.control.has-addons.has-addons-fullwidth .button,
+.control.has-addons.has-addons-fullwidth .input,
+.control.has-addons.has-addons-fullwidth .select,
+.control.has-addons.has-addons-fullwidth .textarea {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+.control.has-icon:not(.has-icon-right) .input,
+.control.has-icon:not(.has-icon-right) .textarea {
+  padding-left: 32px;
+}
+.control.has-icon:not(.has-icon-right) .input.is-small,
+.control.has-icon:not(.has-icon-right) .is-small.textarea {
+  padding-left: 24px;
+}
+.control.has-icon:not(.has-icon-right) .input.is-medium,
+.control.has-icon:not(.has-icon-right) .is-medium.textarea {
+  padding-left: 40px;
+}
+.control.has-icon:not(.has-icon-right) .input.is-large,
+.control.has-icon:not(.has-icon-right) .is-large.textarea {
+  padding-left: 48px;
+}
+.control.has-icon.has-icon-right .input,
+.control.has-icon.has-icon-right .textarea {
+  padding-right: 32px;
+}
+.control.has-icon.has-icon-right .input.is-small,
+.control.has-icon.has-icon-right .is-small.textarea {
+  padding-right: 24px;
+}
+.control.has-icon.has-icon-right .input.is-medium,
+.control.has-icon.has-icon-right .is-medium.textarea {
+  padding-right: 40px;
+}
+.control.has-icon.has-icon-right .input.is-large,
+.control.has-icon.has-icon-right .is-large.textarea {
+  padding-right: 48px;
+}
+.control.is-grouped {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+.control.is-grouped > .control:not(:last-child) {
+  margin-bottom: 0;
+  margin-right: 10px;
+}
+.control.is-grouped > .control.is-expanded {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+.control.is-grouped.is-grouped-centered {
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+.control.is-grouped.is-grouped-right {
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+@media screen and (min-width: 769px) {
+  .control.is-horizontal {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .control.is-horizontal > .control {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-flex: 5;
+    -ms-flex-positive: 5;
+    flex-grow: 5;
+  }
+}
+.control.is-loading:after {
+  position: absolute !important;
+  right: 8px;
+  top: 8px;
+}
+.image {
+  display: block;
+  position: relative;
+}
+.image img {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+.image.is-16by9 img,
+.image.is-1by1 img,
+.image.is-2by1 img,
+.image.is-3by2 img,
+.image.is-4by3 img,
+.image.is-square img {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+}
+.image.is-1by1,
+.image.is-square {
+  padding-top: 100%;
+}
+.image.is-4by3 {
+  padding-top: 75%;
+}
+.image.is-3by2 {
+  padding-top: 66.6666%;
+}
+.image.is-16by9 {
+  padding-top: 56.25%;
+}
+.image.is-2by1 {
+  padding-top: 50%;
+}
+.image.is-16x16 {
+  height: 16px;
+  width: 16px;
+}
+.image.is-24x24 {
+  height: 24px;
+  width: 24px;
+}
+.image.is-32x32 {
+  height: 32px;
+  width: 32px;
+}
+.image.is-48x48 {
+  height: 48px;
+  width: 48px;
+}
+.image.is-64x64 {
+  height: 64px;
+  width: 64px;
+}
+.image.is-96x96 {
+  height: 96px;
+  width: 96px;
+}
+.image.is-128x128 {
+  height: 128px;
+  width: 128px;
+}
+.notification {
+  background-color: #f5f7fa;
+  border-radius: 3px;
+  padding: 16px 20px;
+  position: relative;
+}
+.notification:after {
+  clear: both;
+  display: table;
+}
+.notification .delete,
+.notification .modal-close {
+  border-radius: 0 3px;
+  float: right;
+  margin: -16px -20px 0 20px;
+}
+.notification .subtitle,
+.notification .title {
+  color: inherit;
+}
+.notification.is-white {
+  background-color: #fff;
+  color: #111;
+}
+.notification.is-black {
+  background-color: #111;
+  color: #fff;
+}
+.notification.is-light {
+  background-color: #f5f7fa;
+  color: #42464c;
+}
+.notification.is-dark {
+  background-color: #42464c;
+  color: #f5f7fa;
+}
+.notification.is-info,
+.notification.is-primary {
+  background-color: #2077b2;
+  color: #fff;
+}
+.notification.is-success {
+  background-color: #97cd76;
+  color: #fff;
+}
+.notification.is-warning {
+  background-color: #fce473;
+  color: rgba(17, 17, 17, 0.5);
+}
+.notification.is-danger {
+  background-color: #ed6c63;
+  color: #fff;
+}
+.progress {
+  border: none;
+  border-radius: 290486px;
+  display: block;
+  height: 12px;
+  overflow: hidden;
+  padding: 0;
+  width: 100%;
+}
+.progress::-webkit-progress-bar {
+  background-color: #d3d6db;
+}
+.progress::-webkit-progress-value {
+  background-color: #42464c;
+}
+.progress::-moz-progress-bar {
+  background-color: #42464c;
+}
+.progress.is-white::-webkit-progress-value {
+  background-color: #fff;
+}
+.progress.is-white::-moz-progress-bar {
+  background-color: #fff;
+}
+.progress.is-black::-webkit-progress-value {
+  background-color: #111;
+}
+.progress.is-black::-moz-progress-bar {
+  background-color: #111;
+}
+.progress.is-light::-webkit-progress-value {
+  background-color: #f5f7fa;
+}
+.progress.is-light::-moz-progress-bar {
+  background-color: #f5f7fa;
+}
+.progress.is-dark::-webkit-progress-value {
+  background-color: #42464c;
+}
+.progress.is-dark::-moz-progress-bar {
+  background-color: #42464c;
+}
+.progress.is-primary::-webkit-progress-value {
+  background-color: #2077b2;
+}
+.progress.is-primary::-moz-progress-bar {
+  background-color: #2077b2;
+}
+.progress.is-info::-webkit-progress-value {
+  background-color: #2077b2;
+}
+.progress.is-info::-moz-progress-bar {
+  background-color: #2077b2;
+}
+.progress.is-success::-webkit-progress-value {
+  background-color: #97cd76;
+}
+.progress.is-success::-moz-progress-bar {
+  background-color: #97cd76;
+}
+.progress.is-warning::-webkit-progress-value {
+  background-color: #fce473;
+}
+.progress.is-warning::-moz-progress-bar {
+  background-color: #fce473;
+}
+.progress.is-danger::-webkit-progress-value {
+  background-color: #ed6c63;
+}
+.progress.is-danger::-moz-progress-bar {
+  background-color: #ed6c63;
+}
+.progress.is-small {
+  height: 8px;
+}
+.progress.is-medium {
+  height: 16px;
+}
+.progress.is-large {
+  height: 20px;
+}
+.table {
+  background-color: #fff;
+  color: #222324;
+  margin-bottom: 20px;
+  width: 100%;
+}
+.table td,
+.table th {
+  border: 1px solid #d3d6db;
+  border-width: 0 0 1px;
+  padding: 8px 10px;
+  vertical-align: top;
+}
+.table td.is-icon,
+.table th.is-icon {
+  padding: 5px;
+  display: inline-block;
+  font-size: 21px;
+  height: 24px;
+  line-height: 24px;
+  text-align: center;
+  vertical-align: top;
+  width: 24px;
+}
+.table td.is-icon.is-link,
+.table th.is-icon.is-link {
+  padding: 0;
+}
+.table td.is-icon.is-link > a,
+.table th.is-icon.is-link > a {
+  padding: 5px;
+}
+.table td.is-link,
+.table th.is-link {
+  padding: 0;
+}
+.table td.is-link > a,
+.table th.is-link > a {
+  display: block;
+  padding: 8px 10px;
+}
+.table td.is-link > a:hover,
+.table th.is-link > a:hover {
+  background-color: #2077b2;
+  color: #fff;
+}
+.table td.is-narrow,
+.table th.is-narrow {
+  white-space: nowrap;
+  width: 1%;
+}
+.table th {
+  color: #222324;
+  text-align: left;
+}
+.table tr:hover {
+  background-color: #f5f7fa;
+  color: #222324;
+}
+.table thead td,
+.table thead th {
+  border-width: 0 0 2px;
+  color: #aeb1b5;
+}
+.table tbody tr:last-child td,
+.table tbody tr:last-child th {
+  border-bottom-width: 0;
+}
+.table tfoot td,
+.table tfoot th {
+  border-width: 2px 0 0;
+  color: #aeb1b5;
+}
+.table.is-bordered td,
+.table.is-bordered th {
+  border-width: 1px;
+}
+.table.is-bordered tr:last-child td,
+.table.is-bordered tr:last-child th {
+  border-bottom-width: 1px;
+}
+.table.is-narrow td,
+.table.is-narrow th {
+  padding: 5px 10px;
+}
+.table.is-narrow td.is-icon,
+.table.is-narrow th.is-icon {
+  padding: 2px;
+}
+.table.is-narrow td.is-icon.is-link,
+.table.is-narrow th.is-icon.is-link {
+  padding: 0;
+}
+.table.is-narrow td.is-icon.is-link > a,
+.table.is-narrow th.is-icon.is-link > a {
+  padding: 2px;
+}
+.table.is-narrow td.is-link,
+.table.is-narrow th.is-link {
+  padding: 0;
+}
+.table.is-narrow td.is-link > a,
+.table.is-narrow th.is-link > a {
+  padding: 5px 10px;
+}
+.table.is-striped tbody tr:hover {
+  background-color: #eef2f7;
+}
+.table.is-striped tbody tr:nth-child(2n) {
+  background-color: #f5f7fa;
+}
+.table.is-striped tbody tr:nth-child(2n):hover {
+  background-color: #eef2f7;
+}
+.subtitle,
+.title {
+  font-weight: 300;
+  word-break: break-word;
+}
+.subtitle em,
+.subtitle span,
+.title em,
+.title span {
+  font-weight: 300;
+}
+.subtitle a:hover,
+.title a:hover {
+  border-bottom: 1px solid;
+}
+.subtitle strong,
+.title strong {
+  font-weight: 500;
+}
+.subtitle .tag,
+.title .tag {
+  vertical-align: bottom;
+}
+.delete,
+.modal-close,
+.subtitle code {
+  display: inline-block;
+  vertical-align: top;
+}
+.title {
+  color: #222324;
+}
+.title code {
+  display: inline-block;
+  font-size: 28px;
+}
+.title strong {
+  color: inherit;
+}
+.title + .highlight,
+.title + .subtitle {
+  margin-top: -10px;
+}
+.title.is-1 {
+  font-size: 48px;
+}
+.title.is-1 code,
+.title.is-2 {
+  font-size: 40px;
+}
+.title.is-2 code,
+.title.is-3 {
+  font-size: 28px;
+}
+.title.is-3 code,
+.title.is-4 {
+  font-size: 24px;
+}
+.title.is-4 code,
+.title.is-5 {
+  font-size: 18px;
+}
+.title.is-5 code,
+.title.is-6,
+.title.is-6 code {
+  font-size: 14px;
+}
+.title.is-normal {
+  font-weight: 400;
+}
+.title.is-normal strong {
+  font-weight: 700;
+}
+@media screen and (min-width: 769px) {
+  .title + .subtitle {
+    margin-top: -15px;
+  }
+}
+.subtitle {
+  font-size: 18px;
+  line-height: 1.125;
+}
+.subtitle code {
+  border-radius: 3px;
+  font-size: 14px;
+  padding: 2px 3px;
+}
+.subtitle strong {
+  color: #222324;
+}
+.subtitle + .title {
+  margin-top: -20px;
+}
+.subtitle.is-1 {
+  font-size: 48px;
+}
+.subtitle.is-1 code,
+.subtitle.is-2 {
+  font-size: 40px;
+}
+.subtitle.is-2 code,
+.subtitle.is-3 {
+  font-size: 28px;
+}
+.subtitle.is-3 code,
+.subtitle.is-4 {
+  font-size: 24px;
+}
+.subtitle.is-4 code,
+.subtitle.is-5 {
+  font-size: 18px;
+}
+.subtitle.is-5 code,
+.subtitle.is-6,
+.subtitle.is-6 code {
+  font-size: 14px;
+}
+.subtitle.is-normal {
+  font-weight: 400;
+}
+.subtitle.is-normal strong {
+  font-weight: 700;
+}
+.delete,
+.modal-close {
+  background-color: rgba(17, 17, 17, 0.2);
+  border: none;
+  border-radius: 290486px;
+  cursor: pointer;
+  height: 24px;
+  position: relative;
+  width: 24px;
+}
+.delete:after,
+.delete:before,
+.modal-close:after,
+.modal-close:before {
+  background-color: #fff;
+  content: "";
+  display: block;
+  height: 2px;
+  left: 50%;
+  margin-left: -25%;
+  margin-top: -1px;
+  position: absolute;
+  top: 50%;
+  width: 50%;
+}
+.icon,
+.icon.is-large,
+.icon.is-medium,
+.icon.is-small {
+  display: inline-block;
+  vertical-align: top;
+  text-align: center;
+}
+.delete:before,
+.modal-close:before {
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+.delete:after,
+.modal-close:after {
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}
+.delete:hover,
+.modal-close:hover {
+  background-color: rgba(17, 17, 17, 0.5);
+}
+.delete.is-small,
+.is-small.modal-close,
+.tag:not(.is-large) .delete,
+.tag:not(.is-large) .modal-close {
+  height: 16px;
+  width: 16px;
+}
+.delete.is-medium,
+.is-medium.modal-close {
+  height: 32px;
+  width: 32px;
+}
+.delete.is-large,
+.is-large.modal-close {
+  height: 40px;
+  width: 40px;
+}
+.icon {
+  height: 24px;
+  width: 24px;
+  font-size: inherit;
+  line-height: inherit;
+}
+.icon.is-small {
+  font-size: 14px;
+  height: 16px;
+  line-height: 16px;
+  width: 16px;
+}
+.icon.is-medium {
+  font-size: 28px;
+  height: 32px;
+  line-height: 32px;
+  width: 32px;
+}
+.icon.is-large {
+  font-size: 42px;
+  height: 48px;
+  line-height: 48px;
+  width: 48px;
+}
+.hamburger,
+.nav-toggle {
+  cursor: pointer;
+  display: block;
+  height: 50px;
+  position: relative;
+  width: 50px;
+}
+.hamburger span,
+.nav-toggle span {
+  background-color: #42464c;
+  display: block;
+  height: 1px;
+  left: 50%;
+  margin-left: -7px;
+  position: absolute;
+  top: 50%;
+  -webkit-transition: none 86ms ease-out;
+  transition: none 86ms ease-out;
+  -webkit-transition-property: background, left, opacity, -webkit-transform;
+  transition-property: background, left, opacity, -webkit-transform;
+  transition-property: background, left, opacity, transform;
+  transition-property: background, left, opacity, transform, -webkit-transform;
+  width: 15px;
+}
+.card,
+.card-image {
+  position: relative;
+}
+.hamburger span:nth-child(1),
+.nav-toggle span:nth-child(1) {
+  margin-top: -6px;
+}
+.hamburger span:nth-child(2),
+.nav-toggle span:nth-child(2) {
+  margin-top: -1px;
+}
+.hamburger span:nth-child(3),
+.nav-toggle span:nth-child(3) {
+  margin-top: 4px;
+}
+.hamburger:hover,
+.nav-toggle:hover {
+  background-color: #f5f7fa;
+}
+.hamburger.is-active span,
+.is-active.nav-toggle span {
+  background-color: #2077b2;
+}
+.hamburger.is-active span:nth-child(1),
+.is-active.nav-toggle span:nth-child(1) {
+  margin-left: -5px;
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+  -webkit-transform-origin: left top;
+  transform-origin: left top;
+}
+.hamburger.is-active span:nth-child(2),
+.is-active.nav-toggle span:nth-child(2) {
+  opacity: 0;
+}
+.hamburger.is-active span:nth-child(3),
+.is-active.nav-toggle span:nth-child(3) {
+  margin-left: -5px;
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+  -webkit-transform-origin: left bottom;
+  transform-origin: left bottom;
+}
+.heading {
+  display: block;
+  font-size: 11px;
+  margin-bottom: 5px;
+}
+.highlight {
+  font-size: 12px;
+  font-weight: 400;
+  overflow: hidden;
+  padding: 0;
+}
+.highlight pre {
+  overflow: auto;
+}
+.button.is-loading:after,
+.control.is-loading:after,
+.loader {
+  -webkit-animation: spin-around 0.5s infinite linear;
+  animation: spin-around 0.5s infinite linear;
+  border: 2px solid #d3d6db;
+  border-radius: 290486px;
+  border-right-color: transparent;
+  border-top-color: transparent;
+  content: "";
+  display: block;
+  height: 16px;
+  position: relative;
+  width: 16px;
+}
+.number,
+.tag {
+  background-color: #f5f7fa;
+  border-radius: 290486px;
+  vertical-align: top;
+}
+.number {
+  display: inline-block;
+  font-size: 18px;
+}
+.tag {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #42464c;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 12px;
+  height: 24px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 16px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+.tag .delete,
+.tag .modal-close {
+  margin-left: 4px;
+  margin-right: -6px;
+}
+.tag.is-white {
+  background-color: #fff;
+  color: #111;
+}
+.tag.is-black {
+  background-color: #111;
+  color: #fff;
+}
+.tag.is-light {
+  background-color: #f5f7fa;
+  color: #42464c;
+}
+.tag.is-dark {
+  background-color: #42464c;
+  color: #f5f7fa;
+}
+.tag.is-info,
+.tag.is-primary {
+  background-color: #2077b2;
+  color: #fff;
+}
+.tag.is-success {
+  background-color: #97cd76;
+  color: #fff;
+}
+.tag.is-warning {
+  background-color: #fce473;
+  color: rgba(17, 17, 17, 0.5);
+}
+.tag.is-danger {
+  background-color: #ed6c63;
+  color: #fff;
+}
+.tag.is-small {
+  font-size: 11px;
+  height: 20px;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.tag.is-medium {
+  font-size: 14px;
+  height: 32px;
+  padding-left: 14px;
+  padding-right: 14px;
+}
+.media-number,
+.tag.is-large {
+  font-size: 18px;
+  line-height: 24px;
+}
+.tag.is-large {
+  height: 40px;
+  padding-left: 18px;
+  padding-right: 18px;
+}
+.tag.is-large .delete,
+.tag.is-large .modal-close {
+  margin-left: 4px;
+  margin-right: -8px;
+}
+.button,
+.delete,
+.is-unselectable,
+.modal-close,
+.tabs,
+.unselectable {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.card-header {
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  box-shadow: 0 1px 2px rgba(17, 17, 17, 0.1);
+  display: flex;
+  min-height: 40px;
+}
+.card-header-title {
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  color: #222324;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  font-weight: 700;
+  padding: 10px;
+}
+.card-header-icon {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 40px;
+}
+.card-image {
+  display: block;
+}
+.card-content {
+  padding: 20px;
+}
+.card-content .title + .subtitle {
+  margin-top: -20px;
+}
+.card-footer {
+  border-top: 1px solid #d3d6db;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: flex;
+}
+.media .media,
+.media + .media {
+  border-top: 1px solid rgba(211, 214, 219, 0.5);
+}
+.card-footer-item {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 10px;
+}
+.card-footer-item:not(:last-child) {
+  border-right: 1px solid #d3d6db;
+}
+.card {
+  background-color: #fff;
+  box-shadow: 0 2px 3px rgba(17, 17, 17, 0.1), 0 0 0 1px rgba(17, 17, 17, 0.1);
+  color: #42464c;
+  width: 300px;
+}
+.card .media:not(:last-child) {
+  margin-bottom: 10px;
+}
+.card.is-fullwidth {
+  width: 100%;
+}
+.card.is-rounded {
+  border-radius: 5px;
+}
+.column {
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  padding: 10px;
+}
+.columns.is-mobile > .column.is-narrow {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+}
+.columns.is-mobile > .column.is-full {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 100%;
+}
+.columns.is-mobile > .column.is-three-quarters {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 75%;
+}
+.columns.is-mobile > .column.is-two-thirds {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 66.6666%;
+}
+.columns.is-mobile > .column.is-half {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 50%;
+}
+.columns.is-mobile > .column.is-one-third {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 33.3333%;
+}
+.columns.is-mobile > .column.is-one-quarter {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 25%;
+}
+.columns.is-mobile > .column.is-offset-three-quarters {
+  margin-left: 75%;
+}
+.columns.is-mobile > .column.is-offset-two-thirds {
+  margin-left: 66.6666%;
+}
+.columns.is-mobile > .column.is-offset-half {
+  margin-left: 50%;
+}
+.columns.is-mobile > .column.is-offset-one-third {
+  margin-left: 33.3333%;
+}
+.columns.is-mobile > .column.is-offset-one-quarter {
+  margin-left: 25%;
+}
+.columns.is-mobile > .column.is-1 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 8.33333%;
+}
+.columns.is-mobile > .column.is-offset-1 {
+  margin-left: 8.33333%;
+}
+.columns.is-mobile > .column.is-2 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 16.66667%;
+}
+.columns.is-mobile > .column.is-offset-2 {
+  margin-left: 16.66667%;
+}
+.columns.is-mobile > .column.is-3 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 25%;
+}
+.columns.is-mobile > .column.is-offset-3 {
+  margin-left: 25%;
+}
+.columns.is-mobile > .column.is-4 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 33.33333%;
+}
+.columns.is-mobile > .column.is-offset-4 {
+  margin-left: 33.33333%;
+}
+.columns.is-mobile > .column.is-5 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 41.66667%;
+}
+.columns.is-mobile > .column.is-offset-5 {
+  margin-left: 41.66667%;
+}
+.columns.is-mobile > .column.is-6 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 50%;
+}
+.columns.is-mobile > .column.is-offset-6 {
+  margin-left: 50%;
+}
+.columns.is-mobile > .column.is-7 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 58.33333%;
+}
+.columns.is-mobile > .column.is-offset-7 {
+  margin-left: 58.33333%;
+}
+.columns.is-mobile > .column.is-8 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 66.66667%;
+}
+.columns.is-mobile > .column.is-offset-8 {
+  margin-left: 66.66667%;
+}
+.columns.is-mobile > .column.is-9 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 75%;
+}
+.columns.is-mobile > .column.is-offset-9 {
+  margin-left: 75%;
+}
+.columns.is-mobile > .column.is-10 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 83.33333%;
+}
+.columns.is-mobile > .column.is-offset-10 {
+  margin-left: 83.33333%;
+}
+.columns.is-mobile > .column.is-11 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 91.66667%;
+}
+.columns.is-mobile > .column.is-offset-11 {
+  margin-left: 91.66667%;
+}
+.columns.is-mobile > .column.is-12 {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  width: 100%;
+}
+.columns.is-mobile > .column.is-offset-12 {
+  margin-left: 100%;
+}
+@media screen and (max-width: 768px) {
+  .column.is-narrow-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+  }
+  .column.is-full-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-three-quarters-mobile {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds-mobile {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half-mobile {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third-mobile {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter-mobile {
+    margin-left: 25%;
+  }
+  .column.is-1-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 8.33333%;
+  }
+  .column.is-offset-1-mobile {
+    margin-left: 8.33333%;
+  }
+  .column.is-2-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 16.66667%;
+  }
+  .column.is-offset-2-mobile {
+    margin-left: 16.66667%;
+  }
+  .column.is-3-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3-mobile {
+    margin-left: 25%;
+  }
+  .column.is-4-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.33333%;
+  }
+  .column.is-offset-4-mobile {
+    margin-left: 33.33333%;
+  }
+  .column.is-5-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 41.66667%;
+  }
+  .column.is-offset-5-mobile {
+    margin-left: 41.66667%;
+  }
+  .column.is-6-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6-mobile {
+    margin-left: 50%;
+  }
+  .column.is-7-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 58.33333%;
+  }
+  .column.is-offset-7-mobile {
+    margin-left: 58.33333%;
+  }
+  .column.is-8-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.66667%;
+  }
+  .column.is-offset-8-mobile {
+    margin-left: 66.66667%;
+  }
+  .column.is-9-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9-mobile {
+    margin-left: 75%;
+  }
+  .column.is-10-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 83.33333%;
+  }
+  .column.is-offset-10-mobile {
+    margin-left: 83.33333%;
+  }
+  .column.is-11-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 91.66667%;
+  }
+  .column.is-offset-11-mobile {
+    margin-left: 91.66667%;
+  }
+  .column.is-12-mobile {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12-mobile {
+    margin-left: 100%;
+  }
+}
+@media screen and (min-width: 769px) {
+  .column.is-narrow,
+  .column.is-narrow-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+  }
+  .column.is-full,
+  .column.is-full-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters,
+  .column.is-three-quarters-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds,
+  .column.is-two-thirds-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half,
+  .column.is-half-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third,
+  .column.is-one-third-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter,
+  .column.is-one-quarter-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-three-quarters,
+  .column.is-offset-three-quarters-tablet {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds,
+  .column.is-offset-two-thirds-tablet {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half,
+  .column.is-offset-half-tablet {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third,
+  .column.is-offset-one-third-tablet {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter,
+  .column.is-offset-one-quarter-tablet {
+    margin-left: 25%;
+  }
+  .column.is-1,
+  .column.is-1-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 8.33333%;
+  }
+  .column.is-offset-1,
+  .column.is-offset-1-tablet {
+    margin-left: 8.33333%;
+  }
+  .column.is-2,
+  .column.is-2-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 16.66667%;
+  }
+  .column.is-offset-2,
+  .column.is-offset-2-tablet {
+    margin-left: 16.66667%;
+  }
+  .column.is-3,
+  .column.is-3-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3,
+  .column.is-offset-3-tablet {
+    margin-left: 25%;
+  }
+  .column.is-4,
+  .column.is-4-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.33333%;
+  }
+  .column.is-offset-4,
+  .column.is-offset-4-tablet {
+    margin-left: 33.33333%;
+  }
+  .column.is-5,
+  .column.is-5-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 41.66667%;
+  }
+  .column.is-offset-5,
+  .column.is-offset-5-tablet {
+    margin-left: 41.66667%;
+  }
+  .column.is-6,
+  .column.is-6-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6,
+  .column.is-offset-6-tablet {
+    margin-left: 50%;
+  }
+  .column.is-7,
+  .column.is-7-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 58.33333%;
+  }
+  .column.is-offset-7,
+  .column.is-offset-7-tablet {
+    margin-left: 58.33333%;
+  }
+  .column.is-8,
+  .column.is-8-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.66667%;
+  }
+  .column.is-offset-8,
+  .column.is-offset-8-tablet {
+    margin-left: 66.66667%;
+  }
+  .column.is-9,
+  .column.is-9-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9,
+  .column.is-offset-9-tablet {
+    margin-left: 75%;
+  }
+  .column.is-10,
+  .column.is-10-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 83.33333%;
+  }
+  .column.is-offset-10,
+  .column.is-offset-10-tablet {
+    margin-left: 83.33333%;
+  }
+  .column.is-11,
+  .column.is-11-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 91.66667%;
+  }
+  .column.is-offset-11,
+  .column.is-offset-11-tablet {
+    margin-left: 91.66667%;
+  }
+  .column.is-12,
+  .column.is-12-tablet {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12,
+  .column.is-offset-12-tablet {
+    margin-left: 100%;
+  }
+}
+@media screen and (min-width: 980px) {
+  .column.is-narrow-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+  }
+  .column.is-full-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-three-quarters-desktop {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds-desktop {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half-desktop {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third-desktop {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter-desktop {
+    margin-left: 25%;
+  }
+  .column.is-1-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 8.33333%;
+  }
+  .column.is-offset-1-desktop {
+    margin-left: 8.33333%;
+  }
+  .column.is-2-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 16.66667%;
+  }
+  .column.is-offset-2-desktop {
+    margin-left: 16.66667%;
+  }
+  .column.is-3-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3-desktop {
+    margin-left: 25%;
+  }
+  .column.is-4-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.33333%;
+  }
+  .column.is-offset-4-desktop {
+    margin-left: 33.33333%;
+  }
+  .column.is-5-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 41.66667%;
+  }
+  .column.is-offset-5-desktop {
+    margin-left: 41.66667%;
+  }
+  .column.is-6-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6-desktop {
+    margin-left: 50%;
+  }
+  .column.is-7-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 58.33333%;
+  }
+  .column.is-offset-7-desktop {
+    margin-left: 58.33333%;
+  }
+  .column.is-8-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.66667%;
+  }
+  .column.is-offset-8-desktop {
+    margin-left: 66.66667%;
+  }
+  .column.is-9-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9-desktop {
+    margin-left: 75%;
+  }
+  .column.is-10-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 83.33333%;
+  }
+  .column.is-offset-10-desktop {
+    margin-left: 83.33333%;
+  }
+  .column.is-11-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 91.66667%;
+  }
+  .column.is-offset-11-desktop {
+    margin-left: 91.66667%;
+  }
+  .column.is-12-desktop {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12-desktop {
+    margin-left: 100%;
+  }
+}
+@media screen and (min-width: 1180px) {
+  .column.is-narrow-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+  }
+  .column.is-full-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-three-quarters-widescreen {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds-widescreen {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half-widescreen {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third-widescreen {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter-widescreen {
+    margin-left: 25%;
+  }
+  .column.is-1-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 8.33333%;
+  }
+  .column.is-offset-1-widescreen {
+    margin-left: 8.33333%;
+  }
+  .column.is-2-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 16.66667%;
+  }
+  .column.is-offset-2-widescreen {
+    margin-left: 16.66667%;
+  }
+  .column.is-3-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3-widescreen {
+    margin-left: 25%;
+  }
+  .column.is-4-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.33333%;
+  }
+  .column.is-offset-4-widescreen {
+    margin-left: 33.33333%;
+  }
+  .column.is-5-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 41.66667%;
+  }
+  .column.is-offset-5-widescreen {
+    margin-left: 41.66667%;
+  }
+  .column.is-6-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6-widescreen {
+    margin-left: 50%;
+  }
+  .column.is-7-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 58.33333%;
+  }
+  .column.is-offset-7-widescreen {
+    margin-left: 58.33333%;
+  }
+  .column.is-8-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.66667%;
+  }
+  .column.is-offset-8-widescreen {
+    margin-left: 66.66667%;
+  }
+  .column.is-9-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9-widescreen {
+    margin-left: 75%;
+  }
+  .column.is-10-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 83.33333%;
+  }
+  .column.is-offset-10-widescreen {
+    margin-left: 83.33333%;
+  }
+  .column.is-11-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 91.66667%;
+  }
+  .column.is-offset-11-widescreen {
+    margin-left: 91.66667%;
+  }
+  .column.is-12-widescreen {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12-widescreen {
+    margin-left: 100%;
+  }
+}
+.columns {
+  margin-left: -10px;
+  margin-right: -10px;
+  margin-top: -10px;
+}
+.columns:last-child {
+  margin-bottom: -10px;
+}
+.columns:not(:last-child) {
+  margin-bottom: 10px;
+}
+.columns.is-centered {
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+.columns.is-gapless {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+}
+.columns.is-gapless:last-child {
+  margin-bottom: 0;
+}
+.columns.is-gapless:not(:last-child) {
+  margin-bottom: 20px;
+}
+.columns.is-gapless > .column {
+  margin: 0;
+  padding: 0;
+}
+@media screen and (min-width: 769px) {
+  .columns.is-grid {
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+  }
+  .columns.is-grid > .column {
+    max-width: 33.3333%;
+    padding: 10px;
+    width: 33.3333%;
+  }
+  .columns.is-grid > .column + .column {
+    margin-left: 0;
+  }
+}
+.columns.is-mobile {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.columns.is-multiline {
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+.columns.is-vcentered {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  -ms-grid-row-align: center;
+  align-items: center;
+}
+.nav-left,
+.tile {
+  -webkit-box-align: stretch;
+}
+@media screen and (min-width: 769px) {
+  .columns:not(.is-desktop) {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+@media screen and (min-width: 980px) {
+  .columns.is-desktop {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+.tile {
+  -ms-flex-align: stretch;
+  -ms-grid-row-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  min-height: -webkit-min-content;
+  min-height: -moz-min-content;
+  min-height: min-content;
+}
+.level,
+.modal {
+  -ms-grid-row-align: center;
+}
+.tile.is-ancestor {
+  margin-left: -10px;
+  margin-right: -10px;
+  margin-top: -10px;
+}
+.tile.is-ancestor:last-child {
+  margin-bottom: -10px;
+}
+.tile.is-ancestor:not(:last-child) {
+  margin-bottom: 10px;
+}
+.tile.is-child {
+  margin: 0 !important;
+}
+.level-left .level-item:not(:last-child),
+.level-right .level-item:not(:last-child),
+.media-left {
+  margin-right: 10px;
+}
+.tile.is-parent {
+  padding: 10px;
+}
+.tile.is-vertical {
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+.tile.is-vertical > .tile.is-child:not(:last-child) {
+  margin-bottom: 20px !important;
+}
+@media screen and (min-width: 769px) {
+  .tile:not(.is-child) {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .tile.is-1 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 8.33333%;
+  }
+  .tile.is-2 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 16.66667%;
+  }
+  .tile.is-3 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 25%;
+  }
+  .tile.is-4 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 33.33333%;
+  }
+  .tile.is-5 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 41.66667%;
+  }
+  .tile.is-6 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 50%;
+  }
+  .tile.is-7 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 58.33333%;
+  }
+  .tile.is-8 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 66.66667%;
+  }
+  .tile.is-9 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 75%;
+  }
+  .tile.is-10 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 83.33333%;
+  }
+  .tile.is-11 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 91.66667%;
+  }
+  .tile.is-12 {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    width: 100%;
+  }
+}
+.highlight {
+  background-color: #fdf6e3;
+  color: #586e75;
+}
+.highlight .c {
+  color: #93a1a1;
+}
+.highlight .err,
+.highlight .g {
+  color: #586e75;
+}
+.highlight .k {
+  color: #859900;
+}
+.highlight .l,
+.highlight .n {
+  color: #586e75;
+}
+.highlight .o {
+  color: #859900;
+}
+.highlight .x {
+  color: #cb4b16;
+}
+.highlight .p {
+  color: #586e75;
+}
+.highlight .cm {
+  color: #93a1a1;
+}
+.highlight .cp {
+  color: #859900;
+}
+.highlight .c1 {
+  color: #93a1a1;
+}
+.highlight .cs {
+  color: #859900;
+}
+.highlight .gd {
+  color: #2aa198;
+}
+.highlight .ge {
+  color: #586e75;
+  font-style: italic;
+}
+.highlight .gr {
+  color: #dc322f;
+}
+.highlight .gh {
+  color: #cb4b16;
+}
+.highlight .gi {
+  color: #859900;
+}
+.highlight .go,
+.highlight .gp {
+  color: #586e75;
+}
+.highlight .gs {
+  color: #586e75;
+  font-weight: 700;
+}
+.highlight .gu {
+  color: #cb4b16;
+}
+.highlight .gt {
+  color: #586e75;
+}
+.highlight .kc {
+  color: #cb4b16;
+}
+.highlight .kd {
+  color: #268bd2;
+}
+.highlight .kn,
+.highlight .kp {
+  color: #859900;
+}
+.highlight .kr {
+  color: #268bd2;
+}
+.highlight .kt {
+  color: #dc322f;
+}
+.highlight .ld {
+  color: #586e75;
+}
+.highlight .m,
+.highlight .s {
+  color: #2aa198;
+}
+.highlight .na {
+  color: #b58900;
+}
+.highlight .nb {
+  color: #586e75;
+}
+.highlight .nc {
+  color: #268bd2;
+}
+.highlight .no {
+  color: #cb4b16;
+}
+.highlight .nd {
+  color: #268bd2;
+}
+.highlight .ne,
+.highlight .ni {
+  color: #cb4b16;
+}
+.highlight .nf {
+  color: #268bd2;
+}
+.highlight .nl,
+.highlight .nn,
+.highlight .nx,
+.highlight .py {
+  color: #586e75;
+}
+.highlight .nt,
+.highlight .nv {
+  color: #268bd2;
+}
+.highlight .ow {
+  color: #859900;
+}
+.highlight .w {
+  color: #586e75;
+}
+.highlight .mf,
+.highlight .mh,
+.highlight .mi,
+.highlight .mo {
+  color: #2aa198;
+}
+.highlight .sb {
+  color: #93a1a1;
+}
+.highlight .sc {
+  color: #2aa198;
+}
+.highlight .sd {
+  color: #586e75;
+}
+.highlight .s2 {
+  color: #2aa198;
+}
+.highlight .se {
+  color: #cb4b16;
+}
+.highlight .sh {
+  color: #586e75;
+}
+.highlight .si,
+.highlight .sx {
+  color: #2aa198;
+}
+.highlight .sr {
+  color: #dc322f;
+}
+.highlight .s1,
+.highlight .ss {
+  color: #2aa198;
+}
+.highlight .bp,
+.highlight .vc,
+.highlight .vg,
+.highlight .vi {
+  color: #268bd2;
+}
+.highlight .il {
+  color: #2aa198;
+}
+.level-item .subtitle,
+.level-item .title {
+  margin-bottom: 0;
+}
+.level-left .level-item.is-flexible,
+.level-right .level-item.is-flexible {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+@media screen and (max-width: 768px) {
+  .level-item:not(:last-child) {
+    margin-bottom: 10px;
+  }
+  .level-left + .level-right {
+    margin-top: 20px;
+  }
+}
+@media screen and (min-width: 769px) {
+  .level-left {
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .level-right {
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: end;
+    -ms-flex-pack: end;
+    justify-content: flex-end;
+  }
+}
+.level {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+.level code {
+  border-radius: 3px;
+}
+.level img {
+  display: inline-block;
+  vertical-align: top;
+}
+.level.is-mobile {
+  display: flex;
+}
+.level.is-mobile > .level-item:not(:last-child) {
+  margin-bottom: 0;
+}
+.level.is-mobile > .level-item:not(.is-narrow) {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+@media screen and (min-width: 769px) {
+  .level {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .level > .level-item:not(.is-narrow) {
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+  .media-number {
+    margin-right: 10px;
+  }
+  .media.is-large .media-number {
+    margin-right: 20px;
+  }
+}
+.media-number {
+  background-color: #f5f7fa;
+  border-radius: 290486px;
+  display: inline-block;
+  height: 32px;
+  min-width: 32px;
+  padding: 4px 8px;
+  text-align: center;
+  vertical-align: top;
+}
+@media screen and (max-width: 768px) {
+  .media-number {
+    margin-bottom: 10px;
+  }
+}
+.media-right {
+  margin-left: 10px;
+}
+.media-content {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  text-align: left;
+}
+.media {
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  display: flex;
+  text-align: left;
+}
+.nav,
+.pagination,
+.panel-icon {
+  text-align: center;
+}
+.media .content:not(:last-child) {
+  margin-bottom: 10px;
+}
+.media .media {
+  display: flex;
+  padding-top: 10px;
+}
+.media .media .content:not(:last-child),
+.media .media .control:not(:last-child) {
+  margin-bottom: 5px;
+}
+.media .media .media {
+  padding-top: 5px;
+}
+.media .media .media + .media {
+  margin-top: 5px;
+}
+.media + .media {
+  margin-top: 10px;
+  padding-top: 10px;
+}
+.media.is-large + .media {
+  margin-top: 20px;
+  padding-top: 20px;
+}
+.menu-list a,
+.menu-nav a {
+  display: block;
+  padding: 5px 10px;
+}
+.menu-list a {
+  border-radius: 2px;
+  color: #42464c;
+}
+.menu-list a:hover {
+  background-color: #f5f7fa;
+  color: #2077b2;
+}
+.menu-list a.is-active {
+  background-color: #2077b2;
+  color: #fff;
+}
+.menu-list li ul {
+  border-left: 1px solid #d3d6db;
+  margin: 10px;
+  padding-left: 10px;
+}
+.menu-label {
+  color: #aeb1b5;
+  font-size: 11px;
+  margin-bottom: 5px;
+}
+.menu-label:not(:first-child) {
+  margin-top: 20px;
+}
+.message-body {
+  border: 1px solid #d3d6db;
+  border-radius: 3px;
+  padding: 12px 15px;
+}
+.message-body strong {
+  color: inherit;
+}
+.message-header {
+  background-color: #42464c;
+  border-radius: 3px 3px 0 0;
+  color: #fff;
+  padding: 7px 10px;
+}
+.message-header strong {
+  color: inherit;
+}
+.message-header + .message-body {
+  border-radius: 0 0 3px 3px;
+  border-top: none;
+}
+.message {
+  background-color: #f5f7fa;
+  border-radius: 3px;
+}
+.message.is-white {
+  background-color: #fff;
+}
+.message.is-white .message-header {
+  background-color: #fff;
+  color: #111;
+}
+.message.is-white .message-body {
+  border-color: #fff;
+  color: #666;
+}
+.message.is-black {
+  background-color: #f5f5f5;
+}
+.message.is-black .message-header {
+  background-color: #111;
+  color: #fff;
+}
+.message.is-black .message-body {
+  border-color: #111;
+  color: gray;
+}
+.message.is-light {
+  background-color: #f5f7fa;
+}
+.message.is-light .message-header {
+  background-color: #f5f7fa;
+  color: #42464c;
+}
+.message.is-light .message-body {
+  border-color: #f5f7fa;
+  color: #666;
+}
+.message.is-dark {
+  background-color: #f4f5f6;
+}
+.message.is-dark .message-header {
+  background-color: #42464c;
+  color: #f5f7fa;
+}
+.message.is-dark .message-body {
+  border-color: #42464c;
+  color: gray;
+}
+.message.is-primary {
+  background-color: #eef6fc;
+}
+.message.is-primary .message-header {
+  background-color: #2077b2;
+  color: #fff;
+}
+.message.is-primary .message-body {
+  border-color: #2077b2;
+  color: gray;
+}
+.message.is-info {
+  background-color: #eef6fc;
+}
+.message.is-info .message-header {
+  background-color: #2077b2;
+  color: #fff;
+}
+.message.is-info .message-body {
+  border-color: #2077b2;
+  color: gray;
+}
+.message.is-success {
+  background-color: #f4faf0;
+}
+.message.is-success .message-header {
+  background-color: #97cd76;
+  color: #fff;
+}
+.message.is-success .message-body {
+  border-color: #97cd76;
+  color: gray;
+}
+.message.is-warning {
+  background-color: #fffbeb;
+}
+.message.is-warning .message-header {
+  background-color: #fce473;
+  color: rgba(17, 17, 17, 0.5);
+}
+.message.is-warning .message-body {
+  border-color: #fce473;
+  color: #666;
+}
+.message.is-danger {
+  background-color: #fdeeed;
+}
+.message.is-danger .message-header {
+  background-color: #ed6c63;
+  color: #fff;
+}
+.message.is-danger .message-body {
+  border-color: #ed6c63;
+  color: gray;
+}
+.modal-background {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  background-color: rgba(17, 17, 17, 0.86);
+}
+.modal-card,
+.modal-content {
+  margin: 0 20px;
+  max-height: calc(100vh - 160px);
+  overflow: auto;
+  position: relative;
+  width: 100%;
+}
+@media screen and (min-width: 769px) {
+  .modal-card,
+  .modal-content {
+    margin: 0 auto;
+    max-height: calc(100vh - 40px);
+    width: 640px;
+  }
+}
+.modal-close {
+  background: 0 0;
+  height: 40px;
+  position: fixed;
+  right: 20px;
+  top: 20px;
+  width: 40px;
+}
+.hero-video,
+.modal {
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+.modal-card {
+  background-color: #fff;
+  border-radius: 5px;
+  display: flex;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-height: calc(100vh - 40px);
+  overflow: hidden;
+}
+.modal-card-foot,
+.modal-card-head {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #f5f7fa;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  padding: 20px;
+  position: relative;
+}
+.modal-card-head {
+  border-bottom: 1px solid #d3d6db;
+}
+.modal-card-title {
+  color: #222324;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  font-size: 24px;
+  line-height: 1;
+}
+.modal-card-foot {
+  border-top: 1px solid #d3d6db;
+}
+.modal-card-foot .button:not(:last-child) {
+  margin-right: 10px;
+}
+.modal-card-body {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: auto;
+  padding: 20px;
+}
+.modal,
+.nav-left,
+.tabs {
+  overflow: hidden;
+}
+.nav-left,
+.tabs {
+  overflow-x: auto;
+}
+.modal {
+  top: 0;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: none;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: fixed;
+  z-index: 1986;
+}
+.nav-item,
+.pagination {
+  -webkit-box-align: center;
+}
+.modal.is-active {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+@media screen and (min-width: 769px) {
+  .nav-toggle {
+    display: none;
+  }
+}
+.level-item {
+  stroke: currentColor;
+  fill: none;
+  position: relative;
+  top: 0.1111111111111111em;
+}
+.nav-item {
+  -ms-flex-align: center;
+  align-items: center;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 10px;
+}
+.nav-item a {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+.nav-item img {
+  max-height: 24px;
+}
+.nav-item .button + .button {
+  margin-left: 10px;
+}
+.nav-item .tag:first-child {
+  margin-right: 5px;
+}
+.nav-item .tag:last-child {
+  margin-left: 5px;
+}
+.nav-item a,
+a.nav-item {
+  color: #42464c;
+}
+.nav-item a.is-active,
+.nav-item a:hover,
+a.nav-item.is-active,
+a.nav-item:hover {
+  color: #222324;
+}
+.nav-item a.is-tab,
+a.nav-item.is-tab {
+  border-bottom: 1px solid transparent;
+  border-top: 1px solid transparent;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.nav-item a.is-tab:hover,
+a.nav-item.is-tab:hover {
+  border-bottom: 1px solid #2077b2;
+  border-top: 1px solid transparent;
+}
+.nav-item a.is-tab.is-active,
+a.nav-item.is-tab.is-active {
+  border-bottom: 3px solid #2077b2;
+  border-top: 3px solid transparent;
+  color: #2077b2;
+}
+.panel-heading,
+.panel-tabs a {
+  border-bottom: 1px solid #d3d6db;
+}
+@media screen and (max-width: 768px) {
+  .nav-item {
+    -webkit-box-pack: start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+  .nav-menu {
+    background-color: #fff;
+    box-shadow: 0 4px 7px rgba(17, 17, 17, 0.1);
+    left: 0;
+    display: none;
+    right: 0;
+    top: 100%;
+    position: absolute;
+  }
+  .nav-menu .nav-item {
+    border-top: 1px solid rgba(211, 214, 219, 0.5);
+    padding: 10px;
+  }
+  .nav-menu.is-active {
+    display: block;
+  }
+}
+.container > .nav > .nav-left > .nav-item:first-child:not(.is-tab),
+.nav > .container > .nav-left > .nav-item:first-child:not(.is-tab) {
+  padding-left: 0;
+}
+@media screen and (min-width: 769px) and (max-width: 979px) {
+  .nav-menu {
+    padding-right: 20px;
+  }
+}
+.container > .nav > .nav-right > .nav-item:last-child:not(.is-tab),
+.nav > .container > .nav-right > .nav-item:last-child:not(.is-tab) {
+  padding-right: 0;
+}
+.nav-left {
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+.nav,
+.nav-center {
+  -webkit-box-align: stretch;
+}
+.nav-center {
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+@media screen and (min-width: 769px) {
+  .nav-right {
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    -webkit-box-pack: end;
+    -ms-flex-pack: end;
+    justify-content: flex-end;
+  }
+}
+.nav,
+.nav > .container {
+  min-height: 50px;
+}
+.nav {
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  background-color: #fff;
+  display: flex;
+  position: relative;
+  z-index: 2;
+}
+.panel-heading,
+.tabs.is-boxed a:hover,
+a.panel-block:hover {
+  background-color: #f5f7fa;
+}
+.nav > .container {
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: flex;
+  width: 100%;
+}
+.nav.has-shadow {
+  box-shadow: 0 2px 3px rgba(17, 17, 17, 0.1);
+}
+@media screen and (max-width: 979px) {
+  .container > .nav > .nav-left > .nav-item.is-brand:first-child,
+  .nav > .container > .nav-left > .nav-item.is-brand:first-child {
+    padding-left: 20px;
+  }
+}
+.pagination {
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+.pagination ul,
+.tabs a {
+  -webkit-box-align: center;
+}
+.pagination a {
+  display: block;
+  min-width: 32px;
+  padding: 3px 8px;
+}
+.pagination span {
+  color: #aeb1b5;
+  display: block;
+  margin: 0 4px;
+}
+.pagination li {
+  margin: 0 2px;
+}
+.pagination ul {
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+@media screen and (max-width: 768px) {
+  .pagination {
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+  }
+  .pagination > a {
+    width: calc(50% - 5px);
+  }
+  .pagination > a:not(:first-child) {
+    margin-left: 10px;
+  }
+  .pagination li {
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+  .pagination ul {
+    margin-top: 10px;
+  }
+}
+@media screen and (min-width: 769px) {
+  .pagination > a:not(:first-child) {
+    -webkit-box-ordinal-group: 2;
+    -ms-flex-order: 1;
+    order: 1;
+  }
+}
+.panel-icon {
+  display: inline-block;
+  height: 16px;
+  vertical-align: top;
+  width: 16px;
+  color: #aeb1b5;
+  margin: 0 4px 0 -2px;
+  font-size: inherit;
+  line-height: inherit;
+}
+.panel-heading {
+  border-radius: 4px 4px 0 0;
+  color: #222324;
+  font-size: 18px;
+  font-weight: 300;
+  padding: 10px;
+}
+.panel-tabs,
+.tabs.is-small {
+  font-size: 11px;
+}
+.panel-list a {
+  color: #42464c;
+}
+.panel-list a:hover {
+  color: #2077b2;
+}
+.panel-tabs {
+  display: flex;
+  padding: 5px 10px 0;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+.panel-tabs a {
+  margin-bottom: -1px;
+  padding: 5px;
+}
+.panel-tabs a.is-active {
+  border-bottom-color: #222324;
+  color: #222324;
+}
+.panel-block:not(:last-child),
+.panel-tabs:not(:last-child),
+.tabs a {
+  border-bottom: 1px solid #d3d6db;
+}
+.panel-block {
+  color: #222324;
+  display: block;
+  line-height: 16px;
+  padding: 10px;
+}
+.panel {
+  border: 1px solid #d3d6db;
+  border-radius: 5px;
+}
+.panel:not(:last-child) {
+  margin-bottom: 20px;
+}
+.tabs {
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  line-height: 24px;
+}
+.tabs a {
+  -ms-flex-align: center;
+  align-items: center;
+  color: #42464c;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-bottom: -1px;
+  padding: 6px 12px;
+  vertical-align: top;
+}
+.tabs ul.is-center,
+.tabs ul.is-left {
+  padding-right: 10px;
+}
+.tabs.is-boxed a,
+.tabs.is-toggle a {
+  padding-bottom: 5px;
+  padding-top: 5px;
+}
+.tabs a:hover {
+  border-bottom-color: #222324;
+  color: #222324;
+}
+.tabs li {
+  display: block;
+}
+.tabs li.is-active a {
+  border-bottom-color: #2077b2;
+  color: #2077b2;
+}
+.tabs ul {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: 1px solid #d3d6db;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+.tabs ul.is-center {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 10px;
+}
+.tabs ul.is-right {
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  padding-left: 10px;
+}
+.tabs .icon:first-child {
+  margin-right: 8px;
+}
+.tabs .icon:last-child {
+  margin-left: 8px;
+}
+.tabs.is-centered ul {
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+.tabs.is-right ul {
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+.tabs.is-boxed a {
+  border: 1px solid transparent;
+  border-radius: 3px 3px 0 0;
+}
+.tabs.is-boxed a:hover {
+  border-bottom-color: #d3d6db;
+}
+.tabs.is-boxed li.is-active a {
+  background-color: #fff;
+  border-color: #d3d6db;
+  border-bottom-color: transparent !important;
+}
+.tabs.is-fullwidth li {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+.tabs.is-toggle a {
+  border: 1px solid #d3d6db;
+  margin-bottom: 0;
+  position: relative;
+}
+.tabs.is-toggle a:hover {
+  background-color: #f5f7fa;
+  border-color: #aeb1b5;
+  z-index: 2;
+}
+.tabs.is-toggle li + li {
+  margin-left: -1px;
+}
+.tabs.is-toggle li:first-child a {
+  border-radius: 3px 0 0 3px;
+}
+.tabs.is-toggle li:last-child a {
+  border-radius: 0 3px 3px 0;
+}
+.tabs.is-toggle li.is-active a {
+  background-color: #2077b2;
+  border-color: #2077b2;
+  color: #fff;
+  z-index: 1;
+}
+.hero .tabs ul,
+.tabs.is-toggle ul {
+  border-bottom: none;
+}
+.tabs.is-small a {
+  padding: 2px 8px;
+}
+.tabs.is-small.is-boxed a,
+.tabs.is-small.is-toggle a {
+  padding-bottom: 1px;
+  padding-top: 1px;
+}
+.tabs.is-medium {
+  font-size: 18px;
+}
+.tabs.is-medium a {
+  padding: 10px 16px;
+}
+.tabs.is-medium.is-boxed a,
+.tabs.is-medium.is-toggle a {
+  padding-bottom: 9px;
+  padding-top: 9px;
+}
+.tabs.is-large {
+  font-size: 28px;
+}
+.tabs.is-large a {
+  padding: 14px 20px;
+}
+.tabs.is-large.is-boxed a,
+.tabs.is-large.is-toggle a {
+  padding-bottom: 13px;
+  padding-top: 13px;
+}
+.hero-video {
+  position: absolute;
+  top: 0;
+  overflow: hidden;
+}
+.hero-video video {
+  left: 50%;
+  min-height: 100%;
+  min-width: 100%;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translate3d(-50%, -50%, 0);
+  transform: translate3d(-50%, -50%, 0);
+}
+.hero-video.is-transparent {
+  opacity: 0.3;
+}
+.hero-buttons {
+  margin-top: 20px;
+}
+@media screen and (max-width: 768px) {
+  .hero-video {
+    display: none;
+  }
+  .hero-buttons .button {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .hero-buttons .button:not(:last-child) {
+    margin-bottom: 10px;
+  }
+}
+@media screen and (min-width: 769px) {
+  .hero-buttons {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+  }
+  .hero-buttons .button:not(:last-child) {
+    margin-right: 20px;
+  }
+}
+.hero-foot,
+.hero-head {
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+.hero-body {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding: 40px 20px;
+}
+@media screen and (min-width: 980px) {
+  .hero-body {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+.hero {
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  background-color: #fff;
+  display: flex;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+.hero .nav {
+  background: 0 0;
+}
+.hero.is-white {
+  background-color: #fff;
+  color: #111;
+}
+.hero.is-white .title {
+  color: #111;
+}
+.hero.is-white .title a,
+.hero.is-white .title strong {
+  color: inherit;
+}
+.hero.is-white .subtitle {
+  color: rgba(17, 17, 17, 0.7);
+}
+.hero.is-white .subtitle a,
+.hero.is-white .subtitle strong {
+  color: #111;
+}
+.hero.is-white .nav {
+  box-shadow: 0 1px 0 rgba(17, 17, 17, 0.2);
+}
+@media screen and (max-width: 768px) {
+  .hero.is-white .nav-menu {
+    background-color: #fff;
+  }
+}
+.hero.is-white .nav-item a:not(.button),
+.hero.is-white a.nav-item {
+  color: rgba(17, 17, 17, 0.5);
+}
+.hero.is-white .nav-item a:not(.button).is-active,
+.hero.is-white .nav-item a:not(.button):hover,
+.hero.is-white .tabs.is-boxed a,
+.hero.is-white .tabs.is-toggle a,
+.hero.is-white a.nav-item.is-active,
+.hero.is-white a.nav-item:hover {
+  color: #111;
+}
+.hero.is-white .tabs a {
+  color: #111;
+  opacity: 0.5;
+}
+.hero.is-white .tabs a:hover,
+.hero.is-white .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-white .tabs.is-boxed a:hover,
+.hero.is-white .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-white .tabs.is-boxed li.is-active a,
+.hero.is-white .tabs.is-boxed li.is-active a:hover,
+.hero.is-white .tabs.is-toggle li.is-active a,
+.hero.is-white .tabs.is-toggle li.is-active a:hover {
+  background-color: #111;
+  border-color: #111;
+  color: #fff;
+}
+.hero.is-white.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #e6e6e6 0,
+    #fff 71%,
+    #fff 100%
+  );
+  background-image: linear-gradient(141deg, #e6e6e6 0, #fff 71%, #fff 100%);
+}
+@media screen and (max-width: 768px) {
+  .hero.is-white .nav-toggle span {
+    background-color: #111;
+  }
+  .hero.is-white .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-black .nav-menu,
+  .hero.is-white .nav-toggle.is-active span {
+    background-color: #111;
+  }
+  .hero.is-white .nav-menu .nav-item {
+    border-top-color: rgba(17, 17, 17, 0.2);
+  }
+}
+.hero.is-black {
+  background-color: #111;
+  color: #fff;
+}
+.hero.is-black .title {
+  color: #fff;
+}
+.hero.is-black .title a,
+.hero.is-black .title strong {
+  color: inherit;
+}
+.hero.is-black .subtitle {
+  color: rgba(255, 255, 255, 0.7);
+}
+.hero.is-black .subtitle a,
+.hero.is-black .subtitle strong {
+  color: #fff;
+}
+.hero.is-black .nav {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+.hero.is-black .nav-item a:not(.button),
+.hero.is-black a.nav-item {
+  color: rgba(255, 255, 255, 0.5);
+}
+.hero.is-black .nav-item a:not(.button).is-active,
+.hero.is-black .nav-item a:not(.button):hover,
+.hero.is-black .tabs.is-boxed a,
+.hero.is-black .tabs.is-toggle a,
+.hero.is-black a.nav-item.is-active,
+.hero.is-black a.nav-item:hover {
+  color: #fff;
+}
+.hero.is-black .tabs a {
+  color: #fff;
+  opacity: 0.5;
+}
+.hero.is-black .tabs a:hover,
+.hero.is-black .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-black .tabs.is-boxed a:hover,
+.hero.is-black .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-black .tabs.is-boxed li.is-active a,
+.hero.is-black .tabs.is-boxed li.is-active a:hover,
+.hero.is-black .tabs.is-toggle li.is-active a,
+.hero.is-black .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #111;
+}
+.hero.is-black.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #000 0,
+    #111 71%,
+    #1f1c1c 100%
+  );
+  background-image: linear-gradient(141deg, #000 0, #111 71%, #1f1c1c 100%);
+}
+@media screen and (max-width: 768px) {
+  .hero.is-black .nav-toggle span {
+    background-color: #fff;
+  }
+  .hero.is-black .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-black .nav-toggle.is-active span {
+    background-color: #fff;
+  }
+  .hero.is-black .nav-menu .nav-item {
+    border-top-color: rgba(255, 255, 255, 0.2);
+  }
+  .hero.is-light .nav-menu {
+    background-color: #f5f7fa;
+  }
+}
+.hero.is-light {
+  background-color: #f5f7fa;
+  color: #42464c;
+}
+.hero.is-light .title {
+  color: #42464c;
+}
+.hero.is-light .title a,
+.hero.is-light .title strong {
+  color: inherit;
+}
+.hero.is-light .subtitle {
+  color: rgba(66, 70, 76, 0.7);
+}
+.hero.is-light .subtitle a,
+.hero.is-light .subtitle strong {
+  color: #42464c;
+}
+.hero.is-light .nav {
+  box-shadow: 0 1px 0 rgba(66, 70, 76, 0.2);
+}
+.hero.is-light .nav-item a:not(.button),
+.hero.is-light a.nav-item {
+  color: rgba(66, 70, 76, 0.5);
+}
+.hero.is-light .nav-item a:not(.button).is-active,
+.hero.is-light .nav-item a:not(.button):hover,
+.hero.is-light .tabs.is-boxed a,
+.hero.is-light .tabs.is-toggle a,
+.hero.is-light a.nav-item.is-active,
+.hero.is-light a.nav-item:hover {
+  color: #42464c;
+}
+.hero.is-light .tabs a {
+  color: #42464c;
+  opacity: 0.5;
+}
+.hero.is-light .tabs a:hover,
+.hero.is-light .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-dark,
+.hero.is-dark .title {
+  color: #f5f7fa;
+}
+.hero.is-light .tabs.is-boxed a:hover,
+.hero.is-light .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-light .tabs.is-boxed li.is-active a,
+.hero.is-light .tabs.is-boxed li.is-active a:hover,
+.hero.is-light .tabs.is-toggle li.is-active a,
+.hero.is-light .tabs.is-toggle li.is-active a:hover {
+  background-color: #42464c;
+  border-color: #42464c;
+  color: #f5f7fa;
+}
+.hero.is-light.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #d0e0ec 0,
+    #f5f7fa 71%,
+    #fff 100%
+  );
+  background-image: linear-gradient(141deg, #d0e0ec 0, #f5f7fa 71%, #fff 100%);
+}
+@media screen and (max-width: 768px) {
+  .hero.is-light .nav-toggle span {
+    background-color: #42464c;
+  }
+  .hero.is-light .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-dark .nav-menu,
+  .hero.is-light .nav-toggle.is-active span {
+    background-color: #42464c;
+  }
+  .hero.is-light .nav-menu .nav-item {
+    border-top-color: rgba(66, 70, 76, 0.2);
+  }
+}
+.hero.is-dark {
+  background-color: #42464c;
+}
+.hero.is-dark .title a,
+.hero.is-dark .title strong {
+  color: inherit;
+}
+.hero.is-dark .subtitle {
+  color: rgba(245, 247, 250, 0.7);
+}
+.hero.is-dark .subtitle a,
+.hero.is-dark .subtitle strong {
+  color: #f5f7fa;
+}
+.hero.is-dark .nav {
+  box-shadow: 0 1px 0 rgba(245, 247, 250, 0.2);
+}
+.hero.is-info .nav,
+.hero.is-primary .nav,
+.hero.is-success .nav {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+.hero.is-dark .nav-item a:not(.button),
+.hero.is-dark a.nav-item {
+  color: rgba(245, 247, 250, 0.5);
+}
+.hero.is-dark .nav-item a:not(.button).is-active,
+.hero.is-dark .nav-item a:not(.button):hover,
+.hero.is-dark .tabs.is-boxed a,
+.hero.is-dark .tabs.is-toggle a,
+.hero.is-dark a.nav-item.is-active,
+.hero.is-dark a.nav-item:hover {
+  color: #f5f7fa;
+}
+.hero.is-dark .tabs a {
+  color: #f5f7fa;
+  opacity: 0.5;
+}
+.hero.is-dark .tabs a:hover,
+.hero.is-dark .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-dark .tabs.is-boxed a:hover,
+.hero.is-dark .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-dark .tabs.is-boxed li.is-active a,
+.hero.is-dark .tabs.is-boxed li.is-active a:hover,
+.hero.is-dark .tabs.is-toggle li.is-active a,
+.hero.is-dark .tabs.is-toggle li.is-active a:hover {
+  background-color: #f5f7fa;
+  border-color: #f5f7fa;
+  color: #42464c;
+}
+.hero.is-dark.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #262f35 0,
+    #42464c 71%,
+    #4a4e5e 100%
+  );
+  background-image: linear-gradient(
+    141deg,
+    #262f35 0,
+    #42464c 71%,
+    #4a4e5e 100%
+  );
+}
+@media screen and (max-width: 768px) {
+  .hero.is-dark .nav-toggle span {
+    background-color: #f5f7fa;
+  }
+  .hero.is-dark .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-dark .nav-toggle.is-active span {
+    background-color: #f5f7fa;
+  }
+  .hero.is-dark .nav-menu .nav-item {
+    border-top-color: rgba(245, 247, 250, 0.2);
+  }
+  .hero.is-primary .nav-menu {
+    background-color: #2077b2;
+  }
+}
+.hero.is-primary {
+  background-color: #2077b2;
+  color: #fff;
+}
+.hero.is-primary .title {
+  color: #fff;
+}
+.hero.is-primary .title a,
+.hero.is-primary .title strong {
+  color: inherit;
+}
+.hero.is-primary .subtitle {
+  color: rgba(255, 255, 255, 0.7);
+}
+.hero.is-primary .subtitle a,
+.hero.is-primary .subtitle strong {
+  color: #fff;
+}
+.hero.is-primary .nav-item a:not(.button),
+.hero.is-primary a.nav-item {
+  color: rgba(255, 255, 255, 0.5);
+}
+.hero.is-primary .nav-item a:not(.button).is-active,
+.hero.is-primary .nav-item a:not(.button):hover,
+.hero.is-primary .tabs.is-boxed a,
+.hero.is-primary .tabs.is-toggle a,
+.hero.is-primary a.nav-item.is-active,
+.hero.is-primary a.nav-item:hover {
+  color: #fff;
+}
+.hero.is-primary .tabs a {
+  color: #fff;
+  opacity: 0.5;
+}
+.hero.is-primary .tabs a:hover,
+.hero.is-primary .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-primary .tabs.is-boxed a:hover,
+.hero.is-primary .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-primary .tabs.is-boxed li.is-active a,
+.hero.is-primary .tabs.is-boxed li.is-active a:hover,
+.hero.is-primary .tabs.is-toggle li.is-active a,
+.hero.is-primary .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #2077b2;
+}
+.hero.is-primary.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #10718f 0,
+    #2077b2 71%,
+    #1e69ce 100%
+  );
+  background-image: linear-gradient(
+    141deg,
+    #10718f 0,
+    #2077b2 71%,
+    #1e69ce 100%
+  );
+}
+@media screen and (max-width: 768px) {
+  .hero.is-primary .nav-toggle span {
+    background-color: #fff;
+  }
+  .hero.is-primary .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-primary .nav-toggle.is-active span {
+    background-color: #fff;
+  }
+  .hero.is-primary .nav-menu .nav-item {
+    border-top-color: rgba(255, 255, 255, 0.2);
+  }
+  .hero.is-info .nav-menu {
+    background-color: #2077b2;
+  }
+}
+.hero.is-info {
+  background-color: #2077b2;
+  color: #fff;
+}
+.hero.is-info .title {
+  color: #fff;
+}
+.hero.is-info .title a,
+.hero.is-info .title strong {
+  color: inherit;
+}
+.hero.is-info .subtitle {
+  color: rgba(255, 255, 255, 0.7);
+}
+.hero.is-info .subtitle a,
+.hero.is-info .subtitle strong {
+  color: #fff;
+}
+.hero.is-info .nav-item a:not(.button),
+.hero.is-info a.nav-item {
+  color: rgba(255, 255, 255, 0.5);
+}
+.hero.is-info .nav-item a:not(.button).is-active,
+.hero.is-info .nav-item a:not(.button):hover,
+.hero.is-info .tabs.is-boxed a,
+.hero.is-info .tabs.is-toggle a,
+.hero.is-info a.nav-item.is-active,
+.hero.is-info a.nav-item:hover {
+  color: #fff;
+}
+.hero.is-info .tabs a {
+  color: #fff;
+  opacity: 0.5;
+}
+.hero.is-info .tabs a:hover,
+.hero.is-info .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-info .tabs.is-boxed a:hover,
+.hero.is-info .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-info .tabs.is-boxed li.is-active a,
+.hero.is-info .tabs.is-boxed li.is-active a:hover,
+.hero.is-info .tabs.is-toggle li.is-active a,
+.hero.is-info .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #2077b2;
+}
+.hero.is-info.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #10718f 0,
+    #2077b2 71%,
+    #1e69ce 100%
+  );
+  background-image: linear-gradient(
+    141deg,
+    #10718f 0,
+    #2077b2 71%,
+    #1e69ce 100%
+  );
+}
+@media screen and (max-width: 768px) {
+  .hero.is-info .nav-toggle span {
+    background-color: #fff;
+  }
+  .hero.is-info .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-info .nav-toggle.is-active span {
+    background-color: #fff;
+  }
+  .hero.is-info .nav-menu .nav-item {
+    border-top-color: rgba(255, 255, 255, 0.2);
+  }
+  .hero.is-success .nav-menu {
+    background-color: #97cd76;
+  }
+}
+.hero.is-success {
+  background-color: #97cd76;
+  color: #fff;
+}
+.hero.is-success .title {
+  color: #fff;
+}
+.hero.is-success .title a,
+.hero.is-success .title strong {
+  color: inherit;
+}
+.hero.is-success .subtitle {
+  color: rgba(255, 255, 255, 0.7);
+}
+.hero.is-success .subtitle a,
+.hero.is-success .subtitle strong {
+  color: #fff;
+}
+.hero.is-success .nav-item a:not(.button),
+.hero.is-success a.nav-item {
+  color: rgba(255, 255, 255, 0.5);
+}
+.hero.is-success .nav-item a:not(.button).is-active,
+.hero.is-success .nav-item a:not(.button):hover,
+.hero.is-success .tabs.is-boxed a,
+.hero.is-success .tabs.is-toggle a,
+.hero.is-success a.nav-item.is-active,
+.hero.is-success a.nav-item:hover {
+  color: #fff;
+}
+.hero.is-success .tabs a {
+  color: #fff;
+  opacity: 0.5;
+}
+.hero.is-success .tabs a:hover,
+.hero.is-success .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-success .tabs.is-boxed a:hover,
+.hero.is-success .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-success .tabs.is-boxed li.is-active a,
+.hero.is-success .tabs.is-boxed li.is-active a:hover,
+.hero.is-success .tabs.is-toggle li.is-active a,
+.hero.is-success .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #97cd76;
+}
+.hero.is-warning,
+.hero.is-warning .title {
+  color: rgba(17, 17, 17, 0.5);
+}
+.hero.is-success.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #8ecb45 0,
+    #97cd76 71%,
+    #96d885 100%
+  );
+  background-image: linear-gradient(
+    141deg,
+    #8ecb45 0,
+    #97cd76 71%,
+    #96d885 100%
+  );
+}
+@media screen and (max-width: 768px) {
+  .hero.is-success .nav-toggle span {
+    background-color: #fff;
+  }
+  .hero.is-success .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-success .nav-toggle.is-active span {
+    background-color: #fff;
+  }
+  .hero.is-success .nav-menu .nav-item {
+    border-top-color: rgba(255, 255, 255, 0.2);
+  }
+  .hero.is-warning .nav-menu {
+    background-color: #fce473;
+  }
+}
+.hero.is-warning {
+  background-color: #fce473;
+}
+.hero.is-warning .title a,
+.hero.is-warning .title strong {
+  color: inherit;
+}
+.hero.is-warning .subtitle {
+  color: rgba(17, 17, 17, 0.7);
+}
+.hero.is-warning .nav-item a:not(.button),
+.hero.is-warning .nav-item a:not(.button).is-active,
+.hero.is-warning .nav-item a:not(.button):hover,
+.hero.is-warning .subtitle a,
+.hero.is-warning .subtitle strong,
+.hero.is-warning .tabs.is-boxed a,
+.hero.is-warning .tabs.is-toggle a,
+.hero.is-warning a.nav-item,
+.hero.is-warning a.nav-item.is-active,
+.hero.is-warning a.nav-item:hover {
+  color: rgba(17, 17, 17, 0.5);
+}
+.hero.is-warning .nav {
+  box-shadow: 0 1px 0 rgba(17, 17, 17, 0.2);
+}
+.hero.is-warning .tabs a {
+  color: rgba(17, 17, 17, 0.5);
+  opacity: 0.5;
+}
+.hero.is-warning .tabs a:hover,
+.hero.is-warning .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-warning .tabs.is-boxed a:hover,
+.hero.is-warning .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-warning .tabs.is-boxed li.is-active a,
+.hero.is-warning .tabs.is-boxed li.is-active a:hover,
+.hero.is-warning .tabs.is-toggle li.is-active a,
+.hero.is-warning .tabs.is-toggle li.is-active a:hover {
+  background-color: rgba(17, 17, 17, 0.5);
+  border-color: rgba(17, 17, 17, 0.5);
+  color: #fce473;
+}
+.hero.is-warning.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #ffbd3d 0,
+    #fce473 71%,
+    #fffe8a 100%
+  );
+  background-image: linear-gradient(
+    141deg,
+    #ffbd3d 0,
+    #fce473 71%,
+    #fffe8a 100%
+  );
+}
+@media screen and (max-width: 768px) {
+  .hero.is-warning .nav-toggle span {
+    background-color: rgba(17, 17, 17, 0.5);
+  }
+  .hero.is-warning .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-warning .nav-toggle.is-active span {
+    background-color: rgba(17, 17, 17, 0.5);
+  }
+  .hero.is-warning .nav-menu .nav-item {
+    border-top-color: rgba(17, 17, 17, 0.2);
+  }
+  .hero.is-danger .nav-menu {
+    background-color: #ed6c63;
+  }
+}
+.hero.is-danger {
+  background-color: #ed6c63;
+  color: #fff;
+}
+.hero.is-danger .title {
+  color: #fff;
+}
+.hero.is-danger .title a,
+.hero.is-danger .title strong {
+  color: inherit;
+}
+.hero.is-danger .subtitle {
+  color: rgba(255, 255, 255, 0.7);
+}
+.hero.is-danger .subtitle a,
+.hero.is-danger .subtitle strong {
+  color: #fff;
+}
+.hero.is-danger .nav {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+.hero.is-danger .nav-item a:not(.button),
+.hero.is-danger a.nav-item {
+  color: rgba(255, 255, 255, 0.5);
+}
+.hero.is-danger .nav-item a:not(.button).is-active,
+.hero.is-danger .nav-item a:not(.button):hover,
+.hero.is-danger .tabs.is-boxed a,
+.hero.is-danger .tabs.is-toggle a,
+.hero.is-danger a.nav-item.is-active,
+.hero.is-danger a.nav-item:hover {
+  color: #fff;
+}
+.hero.is-danger .tabs a {
+  color: #fff;
+  opacity: 0.5;
+}
+.hero.is-danger .tabs a:hover,
+.hero.is-danger .tabs li.is-active a {
+  opacity: 1;
+}
+.hero.is-danger .tabs.is-boxed a:hover,
+.hero.is-danger .tabs.is-toggle a:hover {
+  background-color: rgba(17, 17, 17, 0.1);
+}
+.hero.is-danger .tabs.is-boxed li.is-active a,
+.hero.is-danger .tabs.is-boxed li.is-active a:hover,
+.hero.is-danger .tabs.is-toggle li.is-active a,
+.hero.is-danger .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #ed6c63;
+}
+.hero.is-danger.is-bold {
+  background-image: -webkit-linear-gradient(
+    309deg,
+    #f32a3e 0,
+    #ed6c63 71%,
+    #f39376 100%
+  );
+  background-image: linear-gradient(
+    141deg,
+    #f32a3e 0,
+    #ed6c63 71%,
+    #f39376 100%
+  );
+}
+@media screen and (max-width: 768px) {
+  .hero.is-danger .nav-toggle span {
+    background-color: #fff;
+  }
+  .hero.is-danger .nav-toggle:hover {
+    background-color: rgba(17, 17, 17, 0.1);
+  }
+  .hero.is-danger .nav-toggle.is-active span {
+    background-color: #fff;
+  }
+  .hero.is-danger .nav-menu .nav-item {
+    border-top-color: rgba(255, 255, 255, 0.2);
+  }
+}
+@media screen and (min-width: 769px) {
+  .hero.is-medium .hero-body {
+    padding-bottom: 120px;
+    padding-top: 120px;
+  }
+  .hero.is-large .hero-body {
+    padding-bottom: 240px;
+    padding-top: 240px;
+  }
+}
+.hero.is-fullheight {
+  min-height: 100vh;
+}
+.hero.is-fullheight .hero-body {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.hero.is-fullheight .hero-body > .container {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+.section {
+  background-color: #fff;
+  padding: 40px 20px;
+}
+@media screen and (min-width: 980px) {
+  .section.is-medium {
+    padding: 120px 20px;
+  }
+  .section.is-large {
+    padding: 240px 20px;
+  }
+}
+.footer {
+  background-color: #f5f7fa;
+  padding: 40px 20px 80px;
+}
+code,
+html {
+  background-color: transparent;
+}
+.footer a,
+.footer a:visited {
+  color: #42464c;
+}
+.footer a:hover,
+.footer a:visited:hover {
+  color: #222324;
+}
+.footer a:not(.icon),
+.footer a:visited:not(.icon) {
+  border-bottom: 1px solid #d3d6db;
+}
+.footer a:not(.icon):hover,
+.footer a:visited:not(.icon):hover {
+  border-bottom-color: #2077b2;
+}
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.content h1:not(:first-child),
+.content h2:not(:first-child),
+.content h3:not(:first-child),
+.content h4:not(:first-child),
+.content h5:not(:first-child),
+.content h6:not(:first-child),
+article + article {
+  margin-top: 80px;
+}
+.content {
+  font-size: 16px;
+  line-height: 1.75;
+}
+.media-content .subtitle + .title {
+  margin-bottom: 10px;
+}
+.media-content .content {
+  line-height: 1.5;
+}
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6,
+.title {
+  line-height: 1.25;
+}
+.hero .nav {
+  box-shadow: none;
+}
+.nav .level-item {
+  margin-left: 10px;
+}
+.subtitle {
+  color: #69707a;
+}
+.title {
+  font-size: 24px;
+}
+.title a {
+  color: #222324;
+}
+.title.notfound {
+  font-size: 20vw;
+}
+code {
+  color: inherit;
+  font-size: 90%;
+}
+.content h1::before,
+.content h2::before,
+.content h3::before,
+.content h4::before,
+.content h5::before,
+.content h6::before {
+  color: #aeb1b5;
+  font-weight: 700;
+}
+.content h1 code,
+.content h2 code,
+.content h3 code,
+.content h4 code,
+.content h5 code,
+.content h6 code {
+  background-color: #8a2be2;
+}
+.content h1 + h2:not(:first-child),
+.content h2 + h3:not(:first-child),
+.content h3 + h4:not(:first-child),
+.content h4 + h5:not(:first-child),
+.content h5 + h6:not(:first-child) {
+  margin-top: 20px;
+}
+.content h1 {
+  font-size: 24px;
+}
+.content h2 {
+  font-size: 22px;
+}
+.content h3 {
+  font-size: 20px;
+}
+.content h4 {
+  font-size: 18px;
+}
+.content h5 {
+  font-size: 17px;
+}
+.content h6 {
+  font-size: 16px;
+}
+.content ol:not(:last-child),
+.content p:not(:last-child),
+.content pre:not(:last-child),
+.content table:not(:last-child),
+.content ul:not(:last-child) {
+  margin-bottom: 1.5em;
+}
+.content table td,
+.content table th {
+  border: 1px solid #d3d6db;
+  padding: 8px 10px;
+  vertical-align: top;
+}
+.content p > code,
+.content > code {
+  font-size: 90%;
+  padding: 2px 4px;
+  margin: 0 2px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background-color: #f8f8f8;
+  color: #42464c;
+}
+.content pre code {
+  font-size: 90%;
+  padding: 1em;
+  line-height: 1.5;
+}
+.content li pre,
+.content li table {
+  margin-bottom: 1.5em;
+}
+img[src$="#c"] {
+  display: block;
+  margin: 0.7rem auto;
+}
+img[src$="#l"] {
+  float: left;
+  margin: 0.7rem;
+}
+img[src$="#r"] {
+  float: right;
+  margin: 0.7rem;
+}
+.related a:not(.button) {
+  border-bottom: none;
+}
+.related a:not(.button):visited {
+  color: #000;
+}
+.related ul {
+  font-size: 17px;
+}


### PR DESCRIPTION
I were going to clean out some unused classes in the CSS, but it will be a pain to do it on minified CSS. Could we have style.css with whitespace in the repo and leave asset minimizing to build tools like Gulp?

I've run [prettier](https://prettier.io/) on style.css in this commit.

I'm sorry for my two earlier PRs, they included some erroneous commits.