### PR TITLE
relURL changed to absURL for custom css

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,7 @@
 {{ end }}
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css"/>
 {{- range .Site.Params.Assets.customCSS -}}
-<link rel='stylesheet' href='{{ . | relURL }}'>
+<link rel='stylesheet' href='{{ . | absURL }}'>
 {{- end -}}
 </head>
 <body>


### PR DESCRIPTION
Looking into [Hemingway](https://github.com/tanksuzuki/hemingway/) I found a [PR](https://github.com/tanksuzuki/hemingway/pull/2) that applies to kiss custom css property.
