### PR TITLE
Fix stylesheet URL

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,7 +11,7 @@
 {{ if .Site.Params.Info.enableSocial }}
 {{- partial "social/opengraph" . -}}
 {{ end }}
-<link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css"/>
+<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css"/>
 {{- range .Site.Params.Assets.customCSS -}}
 <link rel='stylesheet' href='{{ . | absURL }}'>
 {{- end -}}


### PR DESCRIPTION
Apparently this was introduced in 59d4984, possibly a mistake? All other URLs contain a `/` afterwards so I added this one back.