### PR TITLE
 Use params.sections (if present) for sections

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,7 +11,7 @@
 {{ if .Site.Params.Info.enableSocial }}
 {{- partial "social/opengraph" . -}}
 {{ end }}
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css"/>
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}"/>
 {{- range .Site.Params.Assets.customCSS -}}
 <link rel='stylesheet' href='{{ . | absURL }}'>
 {{- end -}}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -20,5 +20,17 @@
         </nav>
       </div>
     </nav>
+
+    <nav class="nav">
+      <div class="nav-left">
+        {{ range first 5 .Data.Pages }}
+            {{ if (isset .Params "static" ) }}
+                {{ if eq .Params.Static true }}
+                    <a class="nav-item" href="{{ .Permalink }}"><h6 class="title is-6">{{ .Title }}</h6></a>
+                {{ end }}
+            {{ end }}
+        {{ end }}
+      </div>
+    </nav>
   </div>
 </section>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -21,16 +21,18 @@
       </div>
     </nav>
 
-    <nav class="nav">
-      <div class="nav-left">
-        {{ range first 5 .Data.Pages }}
-            {{ if (isset .Params "static" ) }}
-                {{ if eq .Params.Static true }}
-                    <a class="nav-item" href="{{ .Permalink }}"><h6 class="title is-6">{{ .Title }}</h6></a>
-                {{ end }}
-            {{ end }}
-        {{ end }}
-      </div>
-    </nav>
+    {{ if (isset .Site.Params "sections" ) }}
+      <nav class="nav">
+        <div class="nav-left">
+          {{- range $section, $printable := .Site.Params.sections -}}
+            {{- if $printable -}}
+              <a class="nav-item" href="{{$section}}">
+                <h2 class="title is-5">{{$printable}}</h2>
+              </a>
+            {{- end -}}
+          {{- end -}}
+        </div>
+      </nav>
+    {{ end }}
   </div>
 </section>


### PR DESCRIPTION
This will add a second nav bar under site name,
with entries from params.sections.

If you don't add these params, generated markup will be exactly like before

Example:
```
[params.sections]
"/" = "~/"
"/posts" = "Posts"
"/projects" = "Projects"
```

![screenshot](https://user-images.githubusercontent.com/4048546/38531306-7d3dfb68-3c6f-11e8-8d24-f7801ea138a4.png)
