### PR TITLE
Removed invisible margin which caused titles to wrap

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
   <div class="container">
     {{ range sort .Paginator.Pages }}
     <article>
-      <div class="subtitle is-6 is-pulled-right">
+      <div class="subtitle tags is-6 is-pulled-right">
         {{ if .Params.tags }}
         {{ partial "tags" .Params.tags }}
         {{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5712,3 +5712,7 @@ img[src$="#r"] {
 .related ul {
   font-size: 17px;
 }
+
+div.subtitle.tags{
+  margin-bottom: 0px;
+}


### PR DESCRIPTION
# Before:
<img width="600" alt="before" src="https://user-images.githubusercontent.com/4048546/40262247-36bda606-5b06-11e8-9658-355d75fd3336.png">

# After:
<img width="600" alt="after" src="https://user-images.githubusercontent.com/4048546/40262252-3c503598-5b06-11e8-8f21-835c3036a401.png">

