### PR TITLE
Added option to hide pages from list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ tags: ["Android", "Apple", "iPhone"] # Adds tags to the post
 cover: https://example.com/img/1/image.jpg # Cover used for OpenGraph and Twitter Cards
 adsenseTop: true # If adsense property is set (params.info.adsense) include an ad above content
 adsenseBottom: true # If adsense property is set (params.info.adsense) include an ad below content
+hidden: true # If true, page will not be shown in the list view
 ```
 
 ## Build

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,6 +2,7 @@
 {{ partial "nav" . }}
 <section class="section">
   <div class="container">
+    {{ $paginator := .Paginate (where .Pages "Params.hidden" "ne" true) }}
     {{ range sort .Paginator.Pages }}
     <article>
       <div class="subtitle tags is-6 is-pulled-right">


### PR DESCRIPTION
Fixes #27. 

Uses frontmatter in page to hide page from list i.e:
```hidden: true```

Needed to add $paginator to ensure Paginate option is properly respected