### PR TITLE
Remove fontawesome icon in "Read more" link

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,9 +17,6 @@
         {{ if .Truncated }}
         <a class="button is-link" href="{{ .Permalink }}" style="height:28px">
           Read more
-          <span class="icon is-small">
-            <i class="fa fa-angle-double-right"></i>
-          </span>
         </a>
         {{ end }}
       </div>


### PR DESCRIPTION
We don't use fontawesome in the template so I guess the extra span for
fontawesome icon after "Read more" text can be removed. This will
also fix the extra spaces at the end of the link when you hover over it.