### PR TITLE
Provide a parameter to disable disqus in a specific page

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,4 +1,4 @@
-{{ if .Site.DisqusShortname }}
+{{ if and (not (eq .Site.DisqusShortname "")) (not .Params.disable_comments) }}
 <section class="section">
   <div class="container">
     <aside><div id="disqus_thread"></div></aside>


### PR DESCRIPTION
It would be great to have an option to disable comments on specific pages like about.