### PR TITLE
Bigger line height in tags and date

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,7 @@
         {{ partial "tags" .Params.tags }}
         {{ end }}
       </div>
-      <h2 class="subtitle is-6">{{ .Date.Format "January 2, 2006" }}</h2>
+      <h2 class="subtitle is-6 date">{{ .Date.Format "January 2, 2006" }}</h2>
       <h1 class="title"><a href="{{ .Permalink }}">{{ .Title }}</a>{{ if .Draft }} ::Draft{{ end }}</h1>
       <div class="content">
         {{ .Summary | plainify | safeHTML }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2600,6 +2600,11 @@ a.box:active {
   font-size: 14px;
 }
 
+.subtitle.tags,
+.subtitle.date {
+  line-height: 1.5em;
+}
+
 .subtitle.is-normal {
   font-weight: 400;
 }


### PR DESCRIPTION
This makes it look better on phones / smaller windows.

**Before:**

<img width="544" alt="Screenshot 2019-03-24 at 11 20 00" src="https://user-images.githubusercontent.com/4048546/54884821-ac473a00-4e75-11e9-9f82-fbac699753d1.png">

**After:**

<img width="544" alt="Screenshot 2019-03-24 at 11 20 42" src="https://user-images.githubusercontent.com/4048546/54884824-b36e4800-4e75-11e9-884c-40a5eca8dc1f.png">
