### PR TITLE
Adds navigation for posts marked as a part of a series. 

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,27 +1,30 @@
 {{ partial "header" . }}
 {{ partial "nav" . }}
 <section class="section">
-  <div class="container">
-    <div class="subtitle tags is-6 is-pulled-right">
-      {{ if .Params.tags }}
-      {{ partial "tags" .Params.tags }}
-      {{ end }}
+    <div class="container">
+        <div class="subtitle tags is-6 is-pulled-right">
+            {{ if .Params.tags }}
+                {{ partial "tags" .Params.tags }}
+            {{ end }}
+        </div>
+        {{if not .Date.IsZero }}
+            <h2 class="subtitle is-6">{{ .Date.Format "January 2, 2006" }}</h2>
+        {{ end }}
+        <h1 class="title">{{ .Title }}</h1>
+        {{ if and (.Site.Params.Info.adsense) (.Params.adsenseTop) }}
+            {{ partial "adsense" . }}
+        {{ end }}
+        <div class="content">
+            {{ .Content }}
+            {{ partial "series_navigation.html" . }}
+            {{ if .Site.Params.Info.related }}
+                <div class="related">{{ partial "related" . }}</div>
+            {{ end }}
+        </div>
+        {{ if and (.Site.Params.Info.adsense)  (.Params.adsenseBottom) }}
+            {{ partial "adsense" . }}
+        {{ end}}
     </div>
-    {{if not .Date.IsZero }}<h2 class="subtitle is-6">{{ .Date.Format "January 2, 2006" }}</h2>{{ end }}
-    <h1 class="title">{{ .Title }}</h1>
-    {{ if and (.Site.Params.Info.adsense) (.Params.adsenseTop) }}
-    {{ partial "adsense" . }}
-    {{ end }}
-    <div class="content">
-      {{ .Content }}
-      {{ if .Site.Params.Info.related }}
-      <div class="related">{{ partial "related" . }}</div>
-      {{ end }}
-    </div>
-    {{ if and (.Site.Params.Info.adsense)  (.Params.adsenseBottom) }}
-    {{ partial "adsense" . }}
-    {{ end}}
-  </div>
 </section>
 {{ if (and (.Site.Params.Info.codeCopy) (findRE "<pre" .Content 1)) }}
     <script src="/js/copycode.js"></script>

--- a/layouts/partials/series_navigation.html
+++ b/layouts/partials/series_navigation.html
@@ -1,0 +1,52 @@
+{{ if .Params.series }}
+    {{ $.Scratch.Add "cur_page_num" 1 }}
+    {{ $.Scratch.Add "total_page_num" 0 }}
+    {{ range where .Site.RegularPages.ByDate "Params.series" .Params.series }}
+        {{ $.Scratch.Add "total_page_num" 1 }}
+        {{ if gt $.Date.Unix .Date.Unix }}
+            {{ $.Scratch.Add "cur_page_num" 1 }}
+            {{ $.Scratch.Set "prev_link" .Permalink }}
+            {{ $.Scratch.Set "prev_title" .Title }}
+        {{ end }}
+    {{ end }}
+    {{ range where .Site.RegularPages.ByDate.Reverse "Params.series" .Params.series }}
+        {{ $.Scratch.Set "first_link" .Permalink }}
+        {{ if lt $.Date.Unix .Date.Unix }}
+            {{ $.Scratch.Set "next_link" .Permalink }}
+            {{ $.Scratch.Set "next_title" .Title }}
+        {{ end }}
+    {{ end }}
+    {{ if or ($.Scratch.Get "next_link") ($.Scratch.Get "prev_link") }}
+        <hr/>
+        <p>Part
+            {{ $.Scratch.Get "cur_page_num" }}
+            of
+            {{ $.Scratch.Get "total_page_num" }}
+            in the
+            <b>{{ .Params.series }}</b>
+            series.</p>
+        <p>
+            {{ if $.Scratch.Get "prev_link" }}
+                {{ if ne ($.Scratch.Get "prev_link") ($.Scratch.Get "first_link") }}
+                    <a href="{{ $.Scratch.Get "first_link" }}">
+                        <i class="fa fa-angle-left"></i>Series Start<i class="fa fa-angle-right"></i>
+                    </a>
+                    |
+                {{ end }}
+                {{ if $.Scratch.Get "prev_link" }}
+                    <a href="{{ $.Scratch.Get "prev_link" }}">
+                        <i class="fa fa-angle-double-left"></i>
+                        {{ $.Scratch.Get "prev_title" }}</a>
+                {{ end }}
+            {{ end }}
+            {{ if and ($.Scratch.Get "next_link") ($.Scratch.Get "prev_link") }}
+                |
+            {{ end }}
+            {{ if $.Scratch.Get "next_link" }}
+                <a href="{{ $.Scratch.Get "next_link" }}">{{ $.Scratch.Get "next_title" }}<i class="fa fa-angle-double-right"></i>
+                </a>
+            </p>
+        {{ end }}
+    {{ end }}
+    <hr>
+    {{ end }}


### PR DESCRIPTION
Context - 
http://www.joesacher.com/blog/2017/08/03/implementing-series-in-hugo/

Kiss has the ability to add related posts, but when you are writing a series of posts, it is helpful to have a way to navigate between them. 

Current implementation is based on the link mentioned above. 

<img width="865" alt="Screenshot 2019-08-18 at 9 07 13 PM" src="https://user-images.githubusercontent.com/1456182/63226782-2ea51180-c1fc-11e9-9ce7-effeb81579c5.png">


1. This _can_ be made configurable from config.toml , would need changes in the pr. 
2. Currently I've added             
{{ partial "series_navigation.html" . }} 
after the content it could be placed above as well.



