### PR TITLE
Add canonical url into head tag

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -23,6 +23,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">
 <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="canonical" href="{{ .Permalink }}">
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="theme-color" content="#ffffff">
 </head>


### PR DESCRIPTION
Add canonical url into head tag for SEO.