### PR TITLE
fixed the syntax highlighting done by chroma

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -174,6 +174,11 @@ pre code {
   color: #42464c;
 }
 
+code[data-lang] {
+  background-color: inherit;
+  color: inherit;
+}
+
 *,
 :after,
 :before {


### PR DESCRIPTION
the default `style.css` file in the kiss theme file didn't differentiate
between code with and without syntax highlighting. as a result, using
the Chroma syntax highlighter doesn't inherit the foreground and
background color of the chosen theme.

the `<code>` element generated by Chroma has an attribute called
`data-lang` whose value is the programming language being highlighted.
we can use `data-lang` in a CSS selector to make Chroma generated `<code>`
inherit the background and foreground color from the theme being used.