### PR TITLE
add taxonomies counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ homeTitle = "" # Title for home page
 poweredby = true # Adds powered by hugo and kiss below Copyright
 related = true # Includes related articles at the bottom of the article
 codeCopy = true # Add copy button above code blocks
+taxonomiesCount = true # Add taxonomies count
 
 [params.features]
 disqusOnDemand = true  # Load Disqus comments on click

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,7 @@ enableSocial = false # Adds OpenGraph and Twitter cards
 homeTitle = "" # Title for home page
 poweredby = true # Adds powered by Hugo and Kiss below Copyright section
 related = true # Includes related articles
+taxonomiesCount = true # Add taxonomies count
 
 [params.opengraph.facebook]
 admins = [] # array of Facebook IDs

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
         {{ end }}
       </div>
       <h2 class="subtitle is-6 date">{{ .Date.Format "January 2, 2006" }}</h2>
-      <h1 class="title"><a href="{{ .Permalink }}">{{ .Title }}</a>{{ if .Draft }} ::Draft{{ end }}</h1>
+      <h1 class="title"><a href="{{ .Permalink }}">{{ .Title }}{{ partial "taxonomies_count" . }}</a>{{ if .Draft }} ::Draft{{ end }}</h1>
       <div class="content">
         {{ .Summary | plainify | safeHTML }}
         {{ if .Truncated }}

--- a/layouts/partials/taxonomies_count.html
+++ b/layouts/partials/taxonomies_count.html
@@ -1,0 +1,13 @@
+{{if .Site.Params.Info.taxonomiesCount}}
+{{ $title := urlize .Title }}
+  {{ range $taxonomy_name, $taxonomy := .Site.Taxonomies }}
+    {{ if eq $.Section $taxonomy_name}}
+      {{ range $key, $value := $taxonomy }}
+        {{ $term := urlize $key }}
+        {{ if eq $title $term }}
+          ({{ $value.Count }})
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
I wanted to show post's number per taxonomies, so I PR that feature.
User can select whether to show number or not.
<br/>
![taxonomies count image](https://user-images.githubusercontent.com/4299644/70852107-e57e7900-1ee0-11ea-8d5a-ceeec5fb4313.png)
