### PR TITLE
close url in tag links

### DIFF
--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,9 +1,9 @@
 {{ range first 1 . }}
-<a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}">#{{ . }}</a>
+<a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}/">#{{ . }}</a>
 {{ end }}
 
 {{ if gt (len .) 1 }}
   {{ range after 1 . }}
-  | <a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}">#{{ . }}</a>
+  | <a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}/">#{{ . }}</a>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Hi,

for navigation it is better to have directory links closed:

`/tags/computers/` instead of `/tags/computers`

Cheers
midzer
