### PR TITLE
tags should not be self-closing in HTML5 (closes #109)

### DIFF
--- a/exampleSite/content/post/migrate-from-jekyll.md
+++ b/exampleSite/content/post/migrate-from-jekyll.md
@@ -118,7 +118,7 @@ is written as this Hugo shortcode:
     <!-- image -->
     <figure {{ with .Get "class" }}class="{{.}}"{{ end }}>
         {{ with .Get "link"}}<a href="{{.}}">{{ end }}
-            <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }} />
+            <img src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"{{ end }}>
         {{ if .Get "link"}}</a>{{ end }}
         {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
         <figcaption>{{ if isset .Params "title" }}

--- a/layouts/partials/analytics/matomo.html
+++ b/layouts/partials/analytics/matomo.html
@@ -11,5 +11,5 @@
   })();
 </script>
 <noscript>
-  <img src="{{ .Site.Params.matomoAnalytics.rootURL }}piwik.php?idsite={{ .Site.Params.matomoAnalytics.siteID }}&amp;rec=1" style="border:0" alt="" />
+  <img src="{{ .Site.Params.matomoAnalytics.rootURL }}piwik.php?idsite={{ .Site.Params.matomoAnalytics.siteID }}&amp;rec=1" style="border:0" alt="">
 </noscript>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" {{ with .Site.LanguageCode }} lang="{{ . }}"{{ end }}>
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 {{ if eq .IsHome false }}
 <title>{{ .Title }} | {{ .Site.Title }}</title>
 {{ else }}
@@ -12,9 +12,9 @@
 {{- partial "social/opengraph" . -}}
 {{ end }}
 {{ if .Site.Params.rss }}
-<link href="{{ .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+<link href="{{ .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}">
 {{ end }}
-<link rel="stylesheet" href="{{ "css/style.css" | relURL }}"/>
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
 {{- range .Site.Params.Assets.customCSS -}}
 <link rel='stylesheet' href='{{ . | absURL }}'>
 {{- end -}}

--- a/layouts/partials/social/opengraph.html
+++ b/layouts/partials/social/opengraph.html
@@ -50,21 +50,21 @@
 {{- $dateFormat := "2006-01-02T15:04:05Z07:00" -}}
 {{- if .IsPage -}}
   {{- if not .PublishDate.IsZero -}}
-    <meta property='article:published_time' content='{{ .PublishDate.Format $dateFormat }}'/>
+    <meta property='article:published_time' content='{{ .PublishDate.Format $dateFormat }}'>
   {{- else if not .Date.IsZero -}}
-    <meta property='article:published_time' content='{{ .Date.Format $dateFormat }}'/>
+    <meta property='article:published_time' content='{{ .Date.Format $dateFormat }}'>
   {{- end -}}
 
   {{- if not .Lastmod.IsZero -}}
-    <meta property='article:modified_time' content='{{ .Lastmod.Format $dateFormat }}'/>
+    <meta property='article:modified_time' content='{{ .Lastmod.Format $dateFormat }}'>
   {{- end -}}
 
   {{- if not .ExpiryDate.IsZero -}}
-    <meta property='article:expiration_time' content='{{ .ExpiryDate.Format $dateFormat }}'/>
+    <meta property='article:expiration_time' content='{{ .ExpiryDate.Format $dateFormat }}'>
   {{- end -}}
 {{- else -}}
   {{- if not .Site.LastChange.IsZero -}}
-    <meta property='og:updated_time' content='{{ .Site.LastChange.Format $dateFormat }}'/>
+    <meta property='og:updated_time' content='{{ .Site.LastChange.Format $dateFormat }}'>
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
This PR fixes a few img, meta and link tags and removes the closing end as there is none in HTML5.