### PR TITLE
Added math equations and google fonts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ authorEmail = "ribice@gmail.com" # Author email
 
 [params.assets]
 customCSS = ["css/custom.css"]
+googleFonts = []
 
 [params.info]
 adsense = "" # Adsense ID (ID only, without ca-pub-)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ taxonomiesCount = true # Add taxonomies count
 
 [params.features]
 disqusOnDemand = true  # Load Disqus comments on click
+mathjax = false
+katex = false
 
 
 [params.opengraph.facebook]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,8 @@ taxonomiesCount = true # Add taxonomies count
 
 [params.features]
 disqusOnDemand = true  # Load Disqus comments on click
+mathjax = false
+katex = false
 
 
 [params.opengraph.facebook]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -15,6 +15,7 @@ authorEmail = "ribice@gmail.com" # Author email
 
 [params.assets]
 customCSS = ["css/custom.css"]
+googleFonts = []
 
 [params.info]
 adsense = "" # Adsense ID (ID only, without ca-pub-)

--- a/layouts/partials/gfonts.html
+++ b/layouts/partials/gfonts.html
@@ -1,0 +1,10 @@
+<link rel="preconnect" href="https://fonts.gstatic.com" />
+<link
+  href="https://fonts.googleapis.com/css2?family=
+{{- range $index, $font := .Site.Params.Assets.googleFonts -}}
+    {{- if $index -}}&family={{- end -}}
+    {{ $font }}
+{{- end -}}
+&display=swap"
+  rel="stylesheet"
+/>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,6 +18,9 @@
 {{- range .Site.Params.Assets.customCSS -}}
 <link rel='stylesheet' href='{{ . | absURL }}'>
 {{- end -}}
+{{ if or .Site.Params.Features.mathjax .Params.mathjax .Site.Params.Features.katex .Params.katex }}
+{{- partial "math" . -}}
+{{ end }}
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,6 +21,9 @@
 {{ if or .Site.Params.Features.mathjax .Params.mathjax .Site.Params.Features.katex .Params.katex }}
 {{- partial "math" . -}}
 {{ end }}
+{{ if .Site.Params.Assets.googleFonts }}
+{{- partial "gfonts" . -}}
+{{ end }}
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">

--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -1,0 +1,46 @@
+{{ if or .Site.Params.Features.mathjax .Params.mathjax }}
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script
+  id="MathJax-script"
+  async
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+></script>
+<script>
+  MathJax = {
+    tex: {
+      inlineMath: [["$", "$"]],
+    },
+  };
+</script>
+{{ end }}
+
+{{ if or .Site.Params.Features.katex .Params.katex }}
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
+  integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X"
+  crossorigin="anonymous"
+/>
+<script
+  defer
+  src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
+  integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4"
+  crossorigin="anonymous"
+></script>
+<script
+  defer
+  src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js"
+  integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa"
+  crossorigin="anonymous"
+></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    renderMathInElement(document.body, {
+      delimiters: [
+        { left: "$$", right: "$$", display: true },
+        { left: "$", right: "$", display: false },
+      ],
+    });
+  });
+</script>
+{{ end }}


### PR DESCRIPTION
I added the support of math equations and Google fonts. Both Mathjax and Katex are supported.

To enable Mathjax, edit `config.toml` to set `mathjax = true` or only set it in the front matter for a specific post. Katex as well.
Both should not be enabled at the same time.

`$$` is used for math block and `$` for inline math. For example:

```
$$
E = mc^2
$$
```

or `$E=mc^2$`.

There is no cost if disabled.

Google fonts can be used for custom font-family. For example, edit `config.toml`:

```toml
[params.assets]
googleFonts = ["Quicksand", "Open Sans"]
customCSS = ["css/custom.css"]
```

`/static/css/custom.css`:

```
body,
button,
input,
select,
textarea {
  font-family: Quicksand, "Open Sans", Helvetica, Tahoma, Arial, STXihei, sans-serif;
}
```

There is no cost if `googleFonts` is an empty list.