### PR TITLE
Name additional CSS and JS files in single page configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ disqusOnDemand = true
 ```
 tags: ["Android", "Apple", "iPhone"] # Adds tags to the post
 image: https://example.com/img/1/image.jpg # Cover used for OpenGraph and Twitter Cards
+css: https://example.com/css/pagestyle.css # Include additional CSS stylesheet
+js: https://example.com/js/script.js # Include JS file
 adsenseTop: true # If adsense property is set (params.info.adsense) include an ad above content
 adsenseBottom: true # If adsense property is set (params.info.adsense) include an ad below content
 hidden: true # If true, page will not be shown in the list view

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,6 +18,12 @@
 {{- range .Site.Params.Assets.customCSS -}}
 <link rel='stylesheet' href='{{ . | absURL }}'>
 {{- end -}}
+{{ if .Params.css }}
+<link rel="stylesheet" href="{{ .Params.css }}">
+{{ end }}
+{{ if .Params.js }}
+<script src="{{ .Params.js }}"></script>
+{{ end }}
 {{ if or .Site.Params.Features.mathjax .Params.mathjax .Site.Params.Features.katex .Params.katex }}
 {{- partial "math" . -}}
 {{ end }}


### PR DESCRIPTION
I extended the `header.html` such that additional CSS and JS files are included when declared in the single page configuration. 